### PR TITLE
Refactor to Eliminate Repetitive Mock Object Creation in TcpMessageMapperTests.java

### DIFF
--- a/spring-integration-ip/src/test/java/org/springframework/integration/ip/tcp/connection/TcpMessageMapperTests.java
+++ b/spring-integration-ip/src/test/java/org/springframework/integration/ip/tcp/connection/TcpMessageMapperTests.java
@@ -74,15 +74,10 @@ public class TcpMessageMapperTests {
 	@Test
 	public void testToMessage() {
 		TcpMessageMapper mapper = new TcpMessageMapper();
-		TcpConnection connection = mock(TcpConnection.class);
-		Socket socket = mock(Socket.class);
+		TcpConnection connection = CreatMockTcpConnection(TEST_PAYLOAD.getBytes(), "MyHost", "1.1.1.1", 1234);
 		InetAddress local = mock(InetAddress.class);
+		Socket socket = creatMockSocket(local);
 		SocketInfo info = new SocketInfo(socket);
-		when(socket.getLocalAddress()).thenReturn(local);
-		when(connection.getPayload()).thenReturn(TEST_PAYLOAD.getBytes());
-		when(connection.getHostName()).thenReturn("MyHost");
-		when(connection.getHostAddress()).thenReturn("1.1.1.1");
-		when(connection.getPort()).thenReturn(1234);
 		when(connection.getSocketInfo()).thenReturn(info);
 		Message<?> message = mapper.toMessage(connection);
 		assertThat(new String((byte[]) message.getPayload())).isEqualTo(TEST_PAYLOAD);
@@ -97,15 +92,10 @@ public class TcpMessageMapperTests {
 	public void testToMessageWithContentType() {
 		TcpMessageMapper mapper = new TcpMessageMapper();
 		mapper.setAddContentTypeHeader(true);
-		TcpConnection connection = mock(TcpConnection.class);
-		Socket socket = mock(Socket.class);
+		TcpConnection connection = CreatMockTcpConnection(TEST_PAYLOAD.getBytes(), "MyHost", "1.1.1.1", 1234);
 		InetAddress local = mock(InetAddress.class);
+		Socket socket = creatMockSocket(local);
 		SocketInfo info = new SocketInfo(socket);
-		when(socket.getLocalAddress()).thenReturn(local);
-		when(connection.getPayload()).thenReturn(TEST_PAYLOAD.getBytes());
-		when(connection.getHostName()).thenReturn("MyHost");
-		when(connection.getHostAddress()).thenReturn("1.1.1.1");
-		when(connection.getPort()).thenReturn(1234);
 		when(connection.getSocketInfo()).thenReturn(info);
 		Message<?> message = mapper.toMessage(connection);
 		assertThat(new String((byte[]) message.getPayload())).isEqualTo(TEST_PAYLOAD);
@@ -124,15 +114,10 @@ public class TcpMessageMapperTests {
 		TcpMessageMapper mapper = new TcpMessageMapper();
 		mapper.setAddContentTypeHeader(true);
 		mapper.setContentType("application/octet-stream;charset=ISO-8859-1");
-		TcpConnection connection = mock(TcpConnection.class);
-		Socket socket = mock(Socket.class);
+		TcpConnection connection = CreatMockTcpConnection(TEST_PAYLOAD.getBytes(), "MyHost", "1.1.1.1", 1234);
 		InetAddress local = mock(InetAddress.class);
+		Socket socket = creatMockSocket(local);
 		SocketInfo info = new SocketInfo(socket);
-		when(socket.getLocalAddress()).thenReturn(local);
-		when(connection.getPayload()).thenReturn(TEST_PAYLOAD.getBytes());
-		when(connection.getHostName()).thenReturn("MyHost");
-		when(connection.getHostAddress()).thenReturn("1.1.1.1");
-		when(connection.getPort()).thenReturn(1234);
 		when(connection.getSocketInfo()).thenReturn(info);
 		Message<?> message = mapper.toMessage(connection);
 		assertThat(new String((byte[]) message.getPayload())).isEqualTo(TEST_PAYLOAD);
@@ -366,11 +351,7 @@ public class TcpMessageMapperTests {
 		MapJsonSerializer deserializer = new MapJsonSerializer();
 		Map<?, ?> map = deserializer.deserialize(new ByteArrayInputStream(json.getBytes("UTF-8")));
 
-		TcpConnection connection = mock(TcpConnection.class);
-		when(connection.getPayload()).thenReturn(map);
-		when(connection.getHostName()).thenReturn("someHost");
-		when(connection.getHostAddress()).thenReturn("1.1.1.1");
-		when(connection.getPort()).thenReturn(1234);
+		TcpConnection connection = CreatMockTcpConnection(map, "someHost", "1.1.1.1", 1234);
 		when(connection.getConnectionId()).thenReturn("someId");
 		Message<?> message = mapper.toMessage(connection);
 		assertThat(message.getPayload()).isEqualTo("foo");
@@ -396,11 +377,7 @@ public class TcpMessageMapperTests {
 
 		DefaultDeserializer deserializer = new DefaultDeserializer();
 		map = (Map<?, ?>) deserializer.deserialize(new ByteArrayInputStream(baos.toByteArray()));
-		TcpConnection connection = mock(TcpConnection.class);
-		when(connection.getPayload()).thenReturn(map);
-		when(connection.getHostName()).thenReturn("someHost");
-		when(connection.getHostAddress()).thenReturn("1.1.1.1");
-		when(connection.getPort()).thenReturn(1234);
+		TcpConnection connection = CreatMockTcpConnection(map, "someHost", "1.1.1.1", 1234);
 		when(connection.getConnectionId()).thenReturn("someId");
 		Message<?> message = mapper.toMessage(connection);
 		assertThat(message.getPayload()).isEqualTo("foo");
@@ -420,11 +397,7 @@ public class TcpMessageMapperTests {
 		MessageConvertingTcpMessageMapper mapper = new MessageConvertingTcpMessageMapper(converter);
 		byte[] bytes = (byte[]) mapper.fromMessage(outMessage);
 
-		TcpConnection connection = mock(TcpConnection.class);
-		when(connection.getPayload()).thenReturn(bytes);
-		when(connection.getHostName()).thenReturn("someHost");
-		when(connection.getHostAddress()).thenReturn("1.1.1.1");
-		when(connection.getPort()).thenReturn(1234);
+		TcpConnection connection = CreatMockTcpConnection(bytes, "someHost", "1.1.1.1", 1234);
 		when(connection.getConnectionId()).thenReturn("someId");
 		Message<?> message = mapper.toMessage(connection);
 		assertThat(message.getPayload()).isEqualTo("foo");
@@ -444,11 +417,7 @@ public class TcpMessageMapperTests {
 		mapper.setBytesMessageMapper(new EmbeddedJsonHeadersMessageMapper());
 		byte[] bytes = (byte[]) mapper.fromMessage(outMessage);
 
-		TcpConnection connection = mock(TcpConnection.class);
-		when(connection.getPayload()).thenReturn(bytes);
-		when(connection.getHostName()).thenReturn("someHost");
-		when(connection.getHostAddress()).thenReturn("1.1.1.1");
-		when(connection.getPort()).thenReturn(1234);
+		TcpConnection connection = CreatMockTcpConnection(bytes, "someHost", "1.1.1.1", 1234);
 		when(connection.getConnectionId()).thenReturn("someId");
 		Message<?> message = mapper.toMessage(connection);
 		assertThat(message.getPayload()).isEqualTo("foo");
@@ -457,6 +426,20 @@ public class TcpMessageMapperTests {
 		assertThat(message.getHeaders().get(IpHeaders.IP_ADDRESS)).isEqualTo("1.1.1.1");
 		assertThat(message.getHeaders().get(IpHeaders.REMOTE_PORT)).isEqualTo(1234);
 		assertThat(message.getHeaders().get(IpHeaders.CONNECTION_ID)).isEqualTo("someId");
+	}
+	public TcpConnection CreatMockTcpConnection(Object bytes, String hostName, String ipAdress, int port){
+		TcpConnection connection = mock(TcpConnection.class);
+		when(connection.getPayload()).thenReturn(bytes);
+		when(connection.getHostName()).thenReturn(hostName);
+		when(connection.getHostAddress()).thenReturn(ipAdress);
+		when(connection.getPort()).thenReturn(port);
+		return connection;
+	}
+	
+	public Socket creatMockSocket(InetAddress local){
+		Socket socket = mock(Socket.class);
+		when(socket.getLocalAddress()).thenReturn(local);
+		return socket;
 	}
 
 }


### PR DESCRIPTION
Hi there!

While working with the `TcpMessageMapperTests` class, I noticed two mock variables repeatedly created across various tests. To simplify the code, I propose a small refactor to eliminate these redundancies, which could reduce the code by 41 lines.

1. **Repetitive Mock TcpConnection Creation**: The creation of a mock `TcpConnection` object repeated in 7 test cases.

2. **Repetitive Mock Socket Creation**: The creation of a mock `Socket` object repeated in 3 test cases.

Specifically, here is the refactoring method I propose:

Creating a mock for `TcpConnection` currently looks like this:

```java
TcpConnection connection = mock(TcpConnection.class);
//other code...
when(connection.getPayload()).thenReturn(TEST_PAYLOAD.getBytes());
when(connection.getHostName()).thenReturn("MyHost");
when(connection.getHostAddress()).thenReturn("1.1.1.1");
when(connection.getPort()).thenReturn(1234);
```

I introduced a method, `CreatMockTcpConnection`:

```java
public TcpConnection CreatMockTcpConnection(Object bytes, String hostName, String ipAdress, int port){
    TcpConnection connection = mock(TcpConnection.class);
    when(connection.getPayload()).thenReturn(bytes);
    when(connection.getHostName()).thenReturn(hostName);
    when(connection.getHostAddress()).thenReturn(ipAdress);
    when(connection.getPort()).thenReturn(port);
    return connection;
}
```

With this method, creating a mock `TcpConnection` becomes:

```java
TcpConnection connection = CreatMockTcpConnection(map, "someHost", "1.1.1.1", 1234);
```


Similarly, for `Socket`, I introduced a method, `creatMockSocket` as follows:

```java
public Socket creatMockSocket(InetAddress local){
    Socket socket = mock(Socket.class);
    when(socket.getLocalAddress()).thenReturn(local);
    return socket;
}
```

This allows us to create mocks on one line as well：


```java
Socket socket = creatMockSocket(local);
```

I created a draft of the PR, you can see the details file changes  [here](https://github.com/gzhao9/spring-integration/pull/1/files).

---

The refactor reduced the test cases by 41 lines of code, and I believe these changes will improve code readability.