### PR TITLE
Eliminatemock object redundancy

### DIFF
--- a/spring-integration-amqp/src/test/java/org/springframework/integration/amqp/channel/DispatcherHasNoSubscribersTests.java
+++ b/spring-integration-amqp/src/test/java/org/springframework/integration/amqp/channel/DispatcherHasNoSubscribersTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2024 the original author or authors.
+ * Copyright 2013-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -14,128 +14,754 @@
  * limitations under the License.
  */
 
-package org.springframework.integration.amqp.channel;
+package org.springframework.integration.amqp.inbound;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Map;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicReference;
 
-import com.rabbitmq.client.AMQP.Queue.DeclareOk;
 import com.rabbitmq.client.Channel;
-import org.apache.commons.logging.Log;
+import org.assertj.core.api.InstanceOfAssertFactories;
 import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
 
-import org.springframework.amqp.core.AmqpTemplate;
-import org.springframework.amqp.core.Message;
-import org.springframework.amqp.core.MessageListener;
+import org.springframework.amqp.core.AcknowledgeMode;
+import org.springframework.amqp.core.MessageProperties;
+import org.springframework.amqp.rabbit.batch.MessageBatch;
+import org.springframework.amqp.rabbit.batch.SimpleBatchingStrategy;
 import org.springframework.amqp.rabbit.connection.Connection;
 import org.springframework.amqp.rabbit.connection.ConnectionFactory;
+import org.springframework.amqp.rabbit.core.RabbitTemplate;
+import org.springframework.amqp.rabbit.listener.AbstractMessageListenerContainer;
 import org.springframework.amqp.rabbit.listener.SimpleMessageListenerContainer;
-import org.springframework.beans.DirectFieldAccessor;
+import org.springframework.amqp.rabbit.listener.api.ChannelAwareBatchMessageListener;
+import org.springframework.amqp.rabbit.listener.api.ChannelAwareMessageListener;
+import org.springframework.amqp.rabbit.retry.MessageBatchRecoverer;
+import org.springframework.amqp.rabbit.support.ListenerExecutionFailedException;
+import org.springframework.amqp.support.AmqpHeaders;
+import org.springframework.amqp.support.converter.Jackson2JsonMessageConverter;
+import org.springframework.amqp.support.converter.MessageConversionException;
+import org.springframework.amqp.support.converter.MessageConverter;
+import org.springframework.amqp.support.converter.SimpleMessageConverter;
 import org.springframework.beans.factory.BeanFactory;
-import org.springframework.integration.test.util.TestUtils;
-import org.springframework.messaging.MessageDeliveryException;
+import org.springframework.integration.StaticMessageHeaderAccessor;
+import org.springframework.integration.amqp.inbound.AmqpInboundChannelAdapter.BatchMode;
+import org.springframework.integration.amqp.support.AmqpMessageHeaderErrorMessageStrategy;
+import org.springframework.integration.amqp.support.DefaultAmqpHeaderMapper;
+import org.springframework.integration.amqp.support.ManualAckListenerExecutionFailedException;
+import org.springframework.integration.channel.DirectChannel;
+import org.springframework.integration.channel.QueueChannel;
+import org.springframework.integration.handler.advice.ErrorMessageSendingRecoverer;
+import org.springframework.integration.json.JsonToObjectTransformer;
+import org.springframework.integration.json.ObjectToJsonTransformer;
+import org.springframework.integration.mapping.support.JsonHeaders;
+import org.springframework.integration.support.MessageBuilder;
+import org.springframework.integration.transformer.MessageTransformingHandler;
+import org.springframework.integration.transformer.Transformer;
+import org.springframework.messaging.Message;
+import org.springframework.messaging.MessagingException;
+import org.springframework.messaging.PollableChannel;
+import org.springframework.messaging.support.GenericMessage;
+import org.springframework.retry.support.RetryTemplate;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
+import static org.assertj.core.api.Assertions.assertThatIllegalArgumentException;
+import static org.assertj.core.api.Assertions.assertThatIllegalStateException;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyBoolean;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.isNull;
+import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.when;
 
 /**
- * @author Gary Russell
  * @author Artem Bilan
+ * @author Gary Russell
  *
- * @since 2.1
- *
+ * @since 3.0
  */
-public class DispatcherHasNoSubscribersTests {
-
+public class InboundEndpointTests {
+	final ConnectionFactory connectionFactory = mock(ConnectionFactory.class);
+	final Channel rabbitChannel = mock(Channel.class);
+	final Channel channel = mock(Channel.class);
+	final Connection connection = mock(Connection.class);
+	
 	@Test
-	public void testPtP() throws Exception {
-		final Channel channel = mock(Channel.class);
-		DeclareOk declareOk = mock(DeclareOk.class);
-		when(declareOk.getQueue()).thenReturn("noSubscribersChannel");
-		when(channel.queueDeclare(anyString(), anyBoolean(), anyBoolean(), anyBoolean(), isNull()))
-				.thenReturn(declareOk);
-		Connection connection = mock(Connection.class);
-		doAnswer(invocation -> channel).when(connection).createChannel(anyBoolean());
-		ConnectionFactory connectionFactory = mock(ConnectionFactory.class);
+	public void testInt2809JavaTypePropertiesToAmqp() throws Exception {
+		doAnswer(invocation -> mock(Channel.class)).when(connection).createChannel(anyBoolean());
 		when(connectionFactory.createConnection()).thenReturn(connection);
 		SimpleMessageListenerContainer container = new SimpleMessageListenerContainer();
 		container.setConnectionFactory(connectionFactory);
-		AmqpTemplate amqpTemplate = mock(AmqpTemplate.class);
+		container.setAcknowledgeMode(AcknowledgeMode.MANUAL);
 
-		PointToPointSubscribableAmqpChannel amqpChannel =
-				new PointToPointSubscribableAmqpChannel("noSubscribersChannel", container, amqpTemplate);
-		amqpChannel.setBeanName("noSubscribersChannel");
-		amqpChannel.setBeanFactory(mock(BeanFactory.class));
-		amqpChannel.afterPropertiesSet();
+		AmqpInboundChannelAdapter adapter = new AmqpInboundChannelAdapter(container);
+		adapter.setMessageConverter(new Jackson2JsonMessageConverter());
 
-		MessageListener listener = container.getMessageListener();
+		PollableChannel channel = new QueueChannel();
 
-		assertThatExceptionOfType(MessageDeliveryException.class)
-				.isThrownBy(() -> listener.onMessage(new Message("Hello world!".getBytes())))
-				.withMessageContaining("Dispatcher has no subscribers for amqp-channel 'noSubscribersChannel'.");
+		adapter.setOutputChannel(channel);
+		adapter.setBeanFactory(mock(BeanFactory.class));
+		adapter.setBindSourceMessage(true);
+		adapter.afterPropertiesSet();
+
+		Object payload = new Foo("bar1");
+
+		Transformer objectToJsonTransformer = new ObjectToJsonTransformer();
+		Message<?> jsonMessage = objectToJsonTransformer.transform(new GenericMessage<>(payload));
+
+		MessageProperties amqpMessageProperties = new MessageProperties();
+		amqpMessageProperties.setDeliveryTag(123L);
+		org.springframework.amqp.core.Message amqpMessage =
+				new SimpleMessageConverter().toMessage(jsonMessage.getPayload(), amqpMessageProperties);
+		DefaultAmqpHeaderMapper.inboundMapper().fromHeadersToRequest(jsonMessage.getHeaders(), amqpMessageProperties);
+
+		ChannelAwareMessageListener listener = (ChannelAwareMessageListener) container.getMessageListener();
+		listener.onMessage(amqpMessage, rabbitChannel);
+
+		Message<?> result = channel.receive(1000);
+		assertThat(result.getPayload()).isEqualTo(payload);
+
+		assertThat(result.getHeaders().get(AmqpHeaders.CHANNEL)).isSameAs(rabbitChannel);
+		assertThat(result.getHeaders().get(AmqpHeaders.DELIVERY_TAG)).isEqualTo(123L);
+		org.springframework.amqp.core.Message sourceData = StaticMessageHeaderAccessor.getSourceData(result);
+		assertThat(sourceData).isSameAs(amqpMessage);
 	}
 
 	@Test
-	public void testPubSub() {
-		final Channel channel = mock(Channel.class);
-		Connection connection = mock(Connection.class);
-		doAnswer(invocation -> channel).when(connection).createChannel(anyBoolean());
-		ConnectionFactory connectionFactory = mock(ConnectionFactory.class);
+	public void testInt2809JavaTypePropertiesFromAmqp() throws Exception {
+		doAnswer(invocation -> mock(Channel.class)).when(connection).createChannel(anyBoolean());
 		when(connectionFactory.createConnection()).thenReturn(connection);
 		SimpleMessageListenerContainer container = new SimpleMessageListenerContainer();
 		container.setConnectionFactory(connectionFactory);
-		AmqpTemplate amqpTemplate = mock(AmqpTemplate.class);
-		PublishSubscribeAmqpChannel amqpChannel =
-				new PublishSubscribeAmqpChannel("noSubscribersChannel", container, amqpTemplate);
-		amqpChannel.setBeanName("noSubscribersChannel");
-		amqpChannel.setBeanFactory(mock(BeanFactory.class));
-		amqpChannel.afterPropertiesSet();
 
-		List<String> logList = insertMockLoggerInListener(amqpChannel);
-		MessageListener listener = container.getMessageListener();
-		listener.onMessage(new Message("Hello world!".getBytes()));
-		verifyLogReceived(logList);
+		AmqpInboundChannelAdapter adapter = new AmqpInboundChannelAdapter(container);
+
+		PollableChannel channel = new QueueChannel();
+
+		adapter.setOutputChannel(channel);
+		adapter.setBeanFactory(mock(BeanFactory.class));
+		adapter.afterPropertiesSet();
+
+		Object payload = new Foo("bar1");
+
+		MessageProperties amqpMessageProperties = new MessageProperties();
+		org.springframework.amqp.core.Message amqpMessage =
+				new Jackson2JsonMessageConverter().toMessage(payload, amqpMessageProperties);
+
+		ChannelAwareMessageListener listener = (ChannelAwareMessageListener) container.getMessageListener();
+		listener.onMessage(amqpMessage, null);
+
+		Message<?> receive = channel.receive(1000);
+
+		Message<?> result = new JsonToObjectTransformer().transform(receive);
+
+		assertThat(result.getPayload()).isEqualTo(payload);
+		org.springframework.amqp.core.Message sourceData = StaticMessageHeaderAccessor.getSourceData(result);
+		assertThat(sourceData).isNull();
 	}
 
-	private static List<String> insertMockLoggerInListener(PublishSubscribeAmqpChannel channel) {
-		SimpleMessageListenerContainer container =
-				TestUtils.getPropertyValue(channel, "container", SimpleMessageListenerContainer.class);
-		Log logger = mock(Log.class);
-		final ArrayList<String> logList = new ArrayList<>();
-		doAnswer(invocation -> {
-			String message = invocation.getArgument(0);
-			if (message.startsWith("Dispatcher has no subscribers")) {
-				logList.add(message);
-			}
-			return null;
-		}).when(logger).warn(anyString(), any(Exception.class));
-		when(logger.isWarnEnabled()).thenReturn(true);
-		Object listener = container.getMessageListener();
-		DirectFieldAccessor dfa = new DirectFieldAccessor(listener);
-		dfa.setPropertyValue("logger", logger);
-		return logList;
+	@Test
+	public void testMessageConverterJsonHeadersHavePrecedenceOverMessageHeaders() throws Exception {
+		doAnswer(invocation -> mock(Channel.class)).when(connection).createChannel(anyBoolean());
+		when(connectionFactory.createConnection()).thenReturn(connection);
+		SimpleMessageListenerContainer container = new SimpleMessageListenerContainer();
+		container.setConnectionFactory(connectionFactory);
+		container.setAcknowledgeMode(AcknowledgeMode.MANUAL);
+
+		DirectChannel channel = new DirectChannel();
+
+		channel.subscribe(new MessageTransformingHandler(message -> {
+			assertThat(message.getHeaders().get(AmqpHeaders.CHANNEL)).isSameAs(rabbitChannel);
+			assertThat(message.getHeaders().get(AmqpHeaders.DELIVERY_TAG)).isEqualTo(123L);
+			return MessageBuilder.fromMessage(message)
+					.setHeader(JsonHeaders.TYPE_ID, "foo")
+					.setHeader(JsonHeaders.CONTENT_TYPE_ID, "bar")
+					.setHeader(JsonHeaders.KEY_TYPE_ID, "baz")
+					.build();
+		}));
+
+		RabbitTemplate rabbitTemplate = spy(new RabbitTemplate());
+		rabbitTemplate.setMessageConverter(new Jackson2JsonMessageConverter());
+
+		CountDownLatch sendLatch = new CountDownLatch(1);
+
+		Mockito.doAnswer(invocation -> {
+					org.springframework.amqp.core.Message message =
+							invocation.getArgument(2);
+					Map<String, Object> headers = message.getMessageProperties().getHeaders();
+					assertThat(headers.containsKey(JsonHeaders.TYPE_ID.replaceFirst(JsonHeaders.PREFIX, ""))).isTrue();
+					assertThat(headers.get(JsonHeaders.TYPE_ID.replaceFirst(JsonHeaders.PREFIX, ""))).isNotEqualTo("foo");
+					assertThat(headers.containsKey(JsonHeaders.CONTENT_TYPE_ID.replaceFirst(JsonHeaders.PREFIX, ""))).isFalse();
+					assertThat(headers.containsKey(JsonHeaders.KEY_TYPE_ID.replaceFirst(JsonHeaders.PREFIX, ""))).isFalse();
+					assertThat(headers.containsKey(JsonHeaders.TYPE_ID)).isFalse();
+					assertThat(headers.containsKey(JsonHeaders.KEY_TYPE_ID)).isFalse();
+					assertThat(headers.containsKey(JsonHeaders.CONTENT_TYPE_ID)).isFalse();
+					sendLatch.countDown();
+					return null;
+				}).when(rabbitTemplate)
+				.send(anyString(), anyString(), any(org.springframework.amqp.core.Message.class), isNull());
+
+		AmqpInboundGateway gateway = new AmqpInboundGateway(container, rabbitTemplate);
+		gateway.setMessageConverter(new Jackson2JsonMessageConverter());
+		gateway.setRequestChannel(channel);
+		gateway.setBeanFactory(mock(BeanFactory.class));
+		gateway.setDefaultReplyTo("foo");
+		gateway.setReplyHeadersMappedLast(true);
+		gateway.afterPropertiesSet();
+
+		Object payload = new Foo("bar1");
+
+		MessageProperties amqpMessageProperties = new MessageProperties();
+		amqpMessageProperties.setDeliveryTag(123L);
+		org.springframework.amqp.core.Message amqpMessage =
+				new Jackson2JsonMessageConverter().toMessage(payload, amqpMessageProperties);
+
+		ChannelAwareMessageListener listener = (ChannelAwareMessageListener) container.getMessageListener();
+		listener.onMessage(amqpMessage, rabbitChannel);
+
+		assertThat(sendLatch.await(10, TimeUnit.SECONDS)).isTrue();
 	}
 
-	private static void verifyLogReceived(final List<String> logList) {
-		assertThat(logList.size() > 0).as("Failed to get expected exception").isTrue();
-		boolean expectedExceptionFound = false;
-		while (logList.size() > 0) {
-			String message = logList.remove(0);
-			assertThat(message).as("Failed to get expected exception").isNotNull();
-			if (message.startsWith("Dispatcher has no subscribers")) {
-				expectedExceptionFound = true;
-				assertThat(message).contains("Dispatcher has no subscribers for amqp-channel 'noSubscribersChannel'.");
-				break;
+	@Test
+	public void testAdapterConversionError() throws Exception {
+		doAnswer(invocation -> mock(Channel.class)).when(connection).createChannel(anyBoolean());
+		when(connectionFactory.createConnection()).thenReturn(connection);
+		SimpleMessageListenerContainer container = new SimpleMessageListenerContainer();
+		container.setConnectionFactory(connectionFactory);
+		AmqpInboundChannelAdapter adapter = new AmqpInboundChannelAdapter(container);
+		QueueChannel outputChannel = new QueueChannel();
+		adapter.setOutputChannel(outputChannel);
+		QueueChannel errorChannel = new QueueChannel();
+		adapter.setErrorChannel(errorChannel);
+		adapter.setMessageConverter(new SimpleMessageConverter() {
+
+			@Override
+			public Object fromMessage(org.springframework.amqp.core.Message message) throws MessageConversionException {
+				throw new MessageConversionException("intended");
 			}
-		}
-		assertThat(expectedExceptionFound).as("Failed to get expected exception").isTrue();
+
+		});
+		adapter.afterPropertiesSet();
+		org.springframework.amqp.core.Message message = mock(org.springframework.amqp.core.Message.class);
+		MessageProperties props = new MessageProperties();
+		props.setDeliveryTag(42L);
+		given(message.getMessageProperties()).willReturn(props);
+		((ChannelAwareMessageListener) container.getMessageListener())
+				.onMessage(message, null);
+		assertThat(outputChannel.receive(0)).isNull();
+		Message<?> received = errorChannel.receive(0);
+		assertThat(received).isNotNull();
+		assertThat(received.getHeaders().get(AmqpMessageHeaderErrorMessageStrategy.AMQP_RAW_MESSAGE)).isNotNull();
+		assertThat(received.getPayload().getClass()).isEqualTo(ListenerExecutionFailedException.class);
+
+		container.setAcknowledgeMode(AcknowledgeMode.MANUAL);
+		adapter.afterPropertiesSet(); // ack mode is now captured during init
+		((ChannelAwareMessageListener) container.getMessageListener())
+				.onMessage(message, channel);
+		assertThat(outputChannel.receive(0)).isNull();
+		received = errorChannel.receive(0);
+		assertThat(received).isNotNull();
+		assertThat(received.getHeaders().get(AmqpMessageHeaderErrorMessageStrategy.AMQP_RAW_MESSAGE)).isNotNull();
+		assertThat(received.getPayload()).isInstanceOf(ManualAckListenerExecutionFailedException.class);
+		ManualAckListenerExecutionFailedException ex = (ManualAckListenerExecutionFailedException) received
+				.getPayload();
+		assertThat(ex.getChannel()).isEqualTo(channel);
+		assertThat(ex.getDeliveryTag()).isEqualTo(props.getDeliveryTag());
+	}
+
+	@Test
+	public void testGatewayConversionError() throws Exception {
+		doAnswer(invocation -> mock(Channel.class)).when(connection).createChannel(anyBoolean());
+		when(connectionFactory.createConnection()).thenReturn(connection);
+		SimpleMessageListenerContainer container = new SimpleMessageListenerContainer();
+		container.setConnectionFactory(connectionFactory);
+		AmqpInboundGateway adapter = new AmqpInboundGateway(container);
+		QueueChannel outputChannel = new QueueChannel();
+		adapter.setRequestChannel(outputChannel);
+		QueueChannel errorChannel = new QueueChannel();
+		adapter.setErrorChannel(errorChannel);
+		adapter.setMessageConverter(new MessageConverter() {
+
+			@Override
+			public org.springframework.amqp.core.Message toMessage(Object object, MessageProperties messageProperties)
+					throws MessageConversionException {
+				throw new MessageConversionException("intended");
+			}
+
+			@Override
+			public Object fromMessage(org.springframework.amqp.core.Message message) throws MessageConversionException {
+				throw new MessageConversionException("intended");
+			}
+
+		});
+		adapter.afterPropertiesSet();
+		org.springframework.amqp.core.Message message = mock(org.springframework.amqp.core.Message.class);
+		MessageProperties props = new MessageProperties();
+		props.setDeliveryTag(42L);
+		given(message.getMessageProperties()).willReturn(props);
+		((ChannelAwareMessageListener) container.getMessageListener())
+				.onMessage(message, null);
+		assertThat(outputChannel.receive(0)).isNull();
+		Message<?> received = errorChannel.receive(0);
+		assertThat(received).isNotNull();
+		assertThat(received.getHeaders().get(AmqpMessageHeaderErrorMessageStrategy.AMQP_RAW_MESSAGE)).isNotNull();
+
+		container.setAcknowledgeMode(AcknowledgeMode.MANUAL);
+		((ChannelAwareMessageListener) container.getMessageListener())
+				.onMessage(message, channel);
+		assertThat(outputChannel.receive(0)).isNull();
+		received = errorChannel.receive(0);
+		assertThat(received).isNotNull();
+		assertThat(received.getHeaders().get(AmqpMessageHeaderErrorMessageStrategy.AMQP_RAW_MESSAGE)).isNotNull();
+		assertThat(received.getPayload()).isInstanceOf(ManualAckListenerExecutionFailedException.class);
+		ManualAckListenerExecutionFailedException ex = (ManualAckListenerExecutionFailedException) received
+				.getPayload();
+		assertThat(ex.getChannel()).isEqualTo(channel);
+		assertThat(ex.getDeliveryTag()).isEqualTo(props.getDeliveryTag());
+	}
+
+	@Test
+	public void testRetryWithinOnMessageAdapter() throws Exception {
+		AbstractMessageListenerContainer container = new SimpleMessageListenerContainer(connectionFactory);
+		AmqpInboundChannelAdapter adapter = new AmqpInboundChannelAdapter(container);
+		adapter.setOutputChannel(new DirectChannel());
+		adapter.setRetryTemplate(new RetryTemplate());
+		QueueChannel errors = new QueueChannel();
+		ErrorMessageSendingRecoverer recoveryCallback = new ErrorMessageSendingRecoverer(errors);
+		recoveryCallback.setErrorMessageStrategy(new AmqpMessageHeaderErrorMessageStrategy());
+		adapter.setRecoveryCallback(recoveryCallback);
+		adapter.afterPropertiesSet();
+		ChannelAwareMessageListener listener = (ChannelAwareMessageListener) container.getMessageListener();
+		listener.onMessage(org.springframework.amqp.core.MessageBuilder.withBody("foo".getBytes())
+				.andProperties(new MessageProperties()).build(), null);
+		Message<?> errorMessage = errors.receive(0);
+		assertThat(errorMessage).isNotNull();
+		assertThat(errorMessage.getPayload()).isInstanceOf(MessagingException.class);
+		MessagingException payload = (MessagingException) errorMessage.getPayload();
+		assertThat(payload.getMessage()).contains("Dispatcher has no");
+		assertThat(StaticMessageHeaderAccessor.getDeliveryAttempt(payload.getFailedMessage()).get()).isEqualTo(3);
+		org.springframework.amqp.core.Message amqpMessage = errorMessage.getHeaders()
+				.get(AmqpMessageHeaderErrorMessageStrategy.AMQP_RAW_MESSAGE,
+						org.springframework.amqp.core.Message.class);
+		assertThat(amqpMessage).isNotNull();
+		assertThat(errors.receive(0)).isNull();
+	}
+
+	@Test
+	public void testRetryWithMessageRecovererOnMessageAdapter() throws Exception {
+		AbstractMessageListenerContainer container = new SimpleMessageListenerContainer(connectionFactory);
+		AmqpInboundChannelAdapter adapter = new AmqpInboundChannelAdapter(container);
+		adapter.setOutputChannel(new DirectChannel());
+		adapter.setRetryTemplate(new RetryTemplate());
+		AtomicReference<org.springframework.amqp.core.Message> recoveredMessage = new AtomicReference<>();
+		AtomicReference<Throwable> recoveredError = new AtomicReference<>();
+		CountDownLatch recoveredLatch = new CountDownLatch(1);
+		adapter.setMessageRecoverer((message, cause) -> {
+			recoveredMessage.set(message);
+			recoveredError.set(cause);
+			recoveredLatch.countDown();
+		});
+		adapter.afterPropertiesSet();
+		ChannelAwareMessageListener listener = (ChannelAwareMessageListener) container.getMessageListener();
+		org.springframework.amqp.core.Message amqpMessage =
+				org.springframework.amqp.core.MessageBuilder.withBody("foo".getBytes())
+						.andProperties(new MessageProperties())
+						.build();
+		listener.onMessage(amqpMessage, null);
+
+		assertThat(recoveredLatch.await(10, TimeUnit.SECONDS)).isTrue();
+
+		assertThat(recoveredError.get())
+				.isInstanceOf(MessagingException.class)
+				.extracting(Throwable::getMessage, InstanceOfAssertFactories.STRING)
+				.contains("Dispatcher has no");
+
+		assertThat(recoveredMessage.get()).isSameAs(amqpMessage);
+	}
+
+	@Test
+	public void testRetryWithinOnMessageGateway() throws Exception {
+		AbstractMessageListenerContainer container = new SimpleMessageListenerContainer(connectionFactory);
+		AmqpInboundGateway adapter = new AmqpInboundGateway(container);
+		adapter.setRequestChannel(new DirectChannel());
+		adapter.setRetryTemplate(new RetryTemplate());
+		QueueChannel errors = new QueueChannel();
+		ErrorMessageSendingRecoverer recoveryCallback = new ErrorMessageSendingRecoverer(errors);
+		recoveryCallback.setErrorMessageStrategy(new AmqpMessageHeaderErrorMessageStrategy());
+		adapter.setRecoveryCallback(recoveryCallback);
+		adapter.afterPropertiesSet();
+		ChannelAwareMessageListener listener = (ChannelAwareMessageListener) container.getMessageListener();
+		listener.onMessage(org.springframework.amqp.core.MessageBuilder.withBody("foo".getBytes())
+				.andProperties(new MessageProperties()).build(), null);
+		Message<?> errorMessage = errors.receive(0);
+		assertThat(errorMessage).isNotNull();
+		assertThat(errorMessage.getPayload()).isInstanceOf(MessagingException.class);
+		MessagingException payload = (MessagingException) errorMessage.getPayload();
+		assertThat(payload.getMessage()).contains("Dispatcher has no");
+		assertThat(StaticMessageHeaderAccessor.getDeliveryAttempt(payload.getFailedMessage()).get()).isEqualTo(3);
+		org.springframework.amqp.core.Message amqpMessage = errorMessage.getHeaders()
+				.get(AmqpMessageHeaderErrorMessageStrategy.AMQP_RAW_MESSAGE,
+						org.springframework.amqp.core.Message.class);
+		assertThat(amqpMessage).isNotNull();
+		assertThat(errors.receive(0)).isNull();
+	}
+
+	@Test
+	public void testRetryWithMessageRecovererOnMessageGateway() throws Exception {
+		AbstractMessageListenerContainer container = new SimpleMessageListenerContainer(connectionFactory);
+		AmqpInboundGateway adapter = new AmqpInboundGateway(container);
+		adapter.setRequestChannel(new DirectChannel());
+		adapter.setRetryTemplate(new RetryTemplate());
+		AtomicReference<org.springframework.amqp.core.Message> recoveredMessage = new AtomicReference<>();
+		AtomicReference<Throwable> recoveredError = new AtomicReference<>();
+		CountDownLatch recoveredLatch = new CountDownLatch(1);
+		adapter.setMessageRecoverer((message, cause) -> {
+			recoveredMessage.set(message);
+			recoveredError.set(cause);
+			recoveredLatch.countDown();
+		});
+		adapter.afterPropertiesSet();
+		ChannelAwareMessageListener listener = (ChannelAwareMessageListener) container.getMessageListener();
+		org.springframework.amqp.core.Message amqpMessage =
+				org.springframework.amqp.core.MessageBuilder.withBody("foo".getBytes())
+						.andProperties(new MessageProperties())
+						.build();
+		listener.onMessage(amqpMessage, null);
+
+		assertThat(recoveredLatch.await(10, TimeUnit.SECONDS)).isTrue();
+
+		assertThat(recoveredError.get())
+				.isInstanceOf(MessagingException.class)
+				.extracting(Throwable::getMessage, InstanceOfAssertFactories.STRING)
+				.contains("Dispatcher has no");
+
+		assertThat(recoveredMessage.get()).isSameAs(amqpMessage);
+	}
+
+	@SuppressWarnings({"unchecked"})
+	@Test
+	public void testBatchAdapter() throws Exception {
+		SimpleMessageListenerContainer container = new SimpleMessageListenerContainer(mock(ConnectionFactory.class));
+		container.setDeBatchingEnabled(false);
+		AmqpInboundChannelAdapter adapter = new AmqpInboundChannelAdapter(container);
+		QueueChannel out = new QueueChannel();
+		adapter.setOutputChannel(out);
+		adapter.afterPropertiesSet();
+		ChannelAwareMessageListener listener = (ChannelAwareMessageListener) container.getMessageListener();
+		SimpleBatchingStrategy bs = new SimpleBatchingStrategy(2, 10_000, 10_000L);
+		MessageProperties messageProperties = new MessageProperties();
+		messageProperties.setContentType("text/plain");
+		org.springframework.amqp.core.Message message =
+				new org.springframework.amqp.core.Message("test1".getBytes(), messageProperties);
+		bs.addToBatch("foo", "bar", message);
+		message = new org.springframework.amqp.core.Message("test2".getBytes(), messageProperties);
+		MessageBatch batched = bs.addToBatch("foo", "bar", message);
+		listener.onMessage(batched.getMessage(), null);
+		Message<?> received = out.receive(0);
+		assertThat(received).isNotNull();
+		assertThat(((List<String>) received.getPayload())).contains("test1", "test2");
+	}
+
+	@SuppressWarnings({"unchecked"})
+	@Test
+	public void testBatchGateway() throws Exception {
+		SimpleMessageListenerContainer container = new SimpleMessageListenerContainer(mock(ConnectionFactory.class));
+		container.setDeBatchingEnabled(false);
+		AmqpInboundGateway gateway = new AmqpInboundGateway(container);
+		QueueChannel out = new QueueChannel();
+		gateway.setRequestChannel(out);
+		gateway.setBindSourceMessage(true);
+		gateway.setReplyTimeout(0);
+		gateway.afterPropertiesSet();
+		ChannelAwareMessageListener listener = (ChannelAwareMessageListener) container.getMessageListener();
+		SimpleBatchingStrategy bs = new SimpleBatchingStrategy(2, 10_000, 10_000L);
+		MessageProperties messageProperties = new MessageProperties();
+		messageProperties.setContentType("text/plain");
+		org.springframework.amqp.core.Message message =
+				new org.springframework.amqp.core.Message("test1".getBytes(), messageProperties);
+		bs.addToBatch("foo", "bar", message);
+		message = new org.springframework.amqp.core.Message("test2".getBytes(), messageProperties);
+		MessageBatch batched = bs.addToBatch("foo", "bar", message);
+		listener.onMessage(batched.getMessage(), null);
+		Message<?> received = out.receive(0);
+		assertThat(received).isNotNull();
+		assertThat(((List<String>) received.getPayload())).contains("test1", "test2");
+		org.springframework.amqp.core.Message sourceData = StaticMessageHeaderAccessor.getSourceData(received);
+		assertThat(sourceData).isSameAs(batched.getMessage());
+	}
+
+	@SuppressWarnings({"unchecked"})
+	@Test
+	public void testConsumerBatchExtract() {
+		SimpleMessageListenerContainer container = new SimpleMessageListenerContainer(mock(ConnectionFactory.class));
+		container.setConsumerBatchEnabled(true);
+		AmqpInboundChannelAdapter adapter = new AmqpInboundChannelAdapter(container);
+		QueueChannel out = new QueueChannel();
+		adapter.setOutputChannel(out);
+		adapter.setBatchMode(BatchMode.EXTRACT_PAYLOADS_WITH_HEADERS);
+		adapter.afterPropertiesSet();
+		ChannelAwareBatchMessageListener listener = (ChannelAwareBatchMessageListener) container.getMessageListener();
+		MessageProperties messageProperties = new MessageProperties();
+		messageProperties.setContentType("text/plain");
+		List<org.springframework.amqp.core.Message> messages = new ArrayList<>();
+		messages.add(new org.springframework.amqp.core.Message("test1".getBytes(), messageProperties));
+		messages.add(new org.springframework.amqp.core.Message("test2".getBytes(), messageProperties));
+		listener.onMessageBatch(messages, null);
+		Message<?> received = out.receive(0);
+		assertThat(received).isNotNull();
+		assertThat(((List<String>) received.getPayload())).contains("test1", "test2");
+		assertThat(received.getHeaders().get(AmqpInboundChannelAdapter.CONSOLIDATED_HEADERS, List.class))
+				.hasSize(2);
+	}
+
+	@SuppressWarnings({"unchecked"})
+	@Test
+	public void testConsumerBatch() {
+		SimpleMessageListenerContainer container = new SimpleMessageListenerContainer(mock(ConnectionFactory.class));
+		container.setConsumerBatchEnabled(true);
+		AmqpInboundChannelAdapter adapter = new AmqpInboundChannelAdapter(container);
+		QueueChannel out = new QueueChannel();
+		adapter.setOutputChannel(out);
+		adapter.afterPropertiesSet();
+		ChannelAwareBatchMessageListener listener = (ChannelAwareBatchMessageListener) container.getMessageListener();
+		MessageProperties messageProperties = new MessageProperties();
+		messageProperties.setContentType("text/plain");
+		List<org.springframework.amqp.core.Message> messages = new ArrayList<>();
+		messages.add(new org.springframework.amqp.core.Message("test1".getBytes(), messageProperties));
+		messages.add(new org.springframework.amqp.core.Message("test2".getBytes(), messageProperties));
+		listener.onMessageBatch(messages, null);
+		Message<?> received = out.receive(0);
+		assertThat(received).isNotNull();
+		assertThat(((List<Message<String>>) received.getPayload()))
+				.extracting(message -> message.getPayload())
+				.contains("test1", "test2");
+	}
+
+	@Test
+	public void testConsumerBatchAndWrongMessageRecoverer() {
+		SimpleMessageListenerContainer container = new SimpleMessageListenerContainer(mock(ConnectionFactory.class));
+		container.setConsumerBatchEnabled(true);
+		AmqpInboundChannelAdapter adapter = new AmqpInboundChannelAdapter(container);
+		adapter.setRetryTemplate(new RetryTemplate());
+		adapter.setMessageRecoverer((message, cause) -> {
+		});
+		assertThatIllegalArgumentException()
+				.isThrownBy(adapter::afterPropertiesSet)
+				.withMessageStartingWith("The 'messageRecoverer' must be an instance of MessageBatchRecoverer " +
+						"when consumer configured for batch mode");
+	}
+
+	@Test
+	public void testExclusiveRecover() {
+		AmqpInboundChannelAdapter adapter = new AmqpInboundChannelAdapter(mock(AbstractMessageListenerContainer.class));
+		adapter.setRetryTemplate(new RetryTemplate());
+		adapter.setMessageRecoverer((message, cause) -> {
+		});
+		adapter.setRecoveryCallback(context -> null);
+		assertThatIllegalStateException()
+				.isThrownBy(adapter::afterPropertiesSet)
+				.withMessageStartingWith("Only one of 'recoveryCallback' or 'messageRecoverer' may be provided, " +
+						"but not both");
+	}
+
+	@Test
+	public void testAdapterConversionErrorConsumerBatchExtract() {
+		doAnswer(invocation -> mock(Channel.class)).when(connection).createChannel(anyBoolean());
+		when(connectionFactory.createConnection()).thenReturn(connection);
+		SimpleMessageListenerContainer container = new SimpleMessageListenerContainer();
+		container.setConnectionFactory(connectionFactory);
+		container.setConsumerBatchEnabled(true);
+		AmqpInboundChannelAdapter adapter = new AmqpInboundChannelAdapter(container);
+		QueueChannel outputChannel = new QueueChannel();
+		adapter.setOutputChannel(outputChannel);
+		QueueChannel errorChannel = new QueueChannel();
+		adapter.setErrorChannel(errorChannel);
+		adapter.setMessageConverter(new SimpleMessageConverter() {
+
+			@Override
+			public Object fromMessage(org.springframework.amqp.core.Message message) throws MessageConversionException {
+				throw new MessageConversionException("intended");
+			}
+
+		});
+		adapter.setBatchMode(BatchMode.EXTRACT_PAYLOADS);
+		adapter.afterPropertiesSet();
+		MessageProperties messageProperties = new MessageProperties();
+		messageProperties.setContentType("text/plain");
+		messageProperties.setDeliveryTag(42L);
+		List<org.springframework.amqp.core.Message> messages = new ArrayList<>();
+		messages.add(new org.springframework.amqp.core.Message("test1".getBytes(), messageProperties));
+		messageProperties = new MessageProperties();
+		messageProperties.setContentType("text/plain");
+		messageProperties.setDeliveryTag(43L);
+		messages.add(new org.springframework.amqp.core.Message("test2".getBytes(), messageProperties));
+		((ChannelAwareBatchMessageListener) container.getMessageListener())
+				.onMessageBatch(messages, null);
+		assertThat(outputChannel.receive(0)).isNull();
+		Message<?> received = errorChannel.receive(0);
+		assertThat(received).isNotNull();
+		assertThat(received.getHeaders().get(AmqpMessageHeaderErrorMessageStrategy.AMQP_RAW_MESSAGE)).isNotNull();
+		assertThat(received.getPayload().getClass()).isEqualTo(ListenerExecutionFailedException.class);
+
+		container.setAcknowledgeMode(AcknowledgeMode.MANUAL);
+		adapter.afterPropertiesSet(); // ack mode is now captured during init
+		((ChannelAwareBatchMessageListener) container.getMessageListener())
+				.onMessageBatch(messages, channel);
+		assertThat(outputChannel.receive(0)).isNull();
+		received = errorChannel.receive(0);
+		assertThat(received).isNotNull();
+		assertThat(received.getHeaders().get(AmqpMessageHeaderErrorMessageStrategy.AMQP_RAW_MESSAGE)).isNotNull();
+		assertThat(received.getPayload()).isInstanceOf(ManualAckListenerExecutionFailedException.class);
+		ManualAckListenerExecutionFailedException ex = (ManualAckListenerExecutionFailedException) received
+				.getPayload();
+		assertThat(ex.getChannel()).isEqualTo(channel);
+		assertThat(ex.getDeliveryTag()).isEqualTo(43L);
+	}
+
+	@Test
+	public void testAdapterConversionErrorConsumerBatch() {
+		doAnswer(invocation -> mock(Channel.class)).when(connection).createChannel(anyBoolean());
+		when(connectionFactory.createConnection()).thenReturn(connection);
+		SimpleMessageListenerContainer container = new SimpleMessageListenerContainer();
+		container.setConnectionFactory(connectionFactory);
+		container.setConsumerBatchEnabled(true);
+		AmqpInboundChannelAdapter adapter = new AmqpInboundChannelAdapter(container);
+		QueueChannel outputChannel = new QueueChannel();
+		adapter.setOutputChannel(outputChannel);
+		QueueChannel errorChannel = new QueueChannel();
+		adapter.setErrorChannel(errorChannel);
+		adapter.setMessageConverter(new SimpleMessageConverter() {
+
+			@Override
+			public Object fromMessage(org.springframework.amqp.core.Message message) throws MessageConversionException {
+				throw new MessageConversionException("intended");
+			}
+
+		});
+		adapter.afterPropertiesSet();
+		MessageProperties messageProperties = new MessageProperties();
+		messageProperties.setContentType("text/plain");
+		messageProperties.setDeliveryTag(42L);
+		List<org.springframework.amqp.core.Message> messages = new ArrayList<>();
+		messages.add(new org.springframework.amqp.core.Message("test1".getBytes(), messageProperties));
+		messageProperties = new MessageProperties();
+		messageProperties.setContentType("text/plain");
+		messageProperties.setDeliveryTag(43L);
+		messages.add(new org.springframework.amqp.core.Message("test2".getBytes(), messageProperties));
+		((ChannelAwareBatchMessageListener) container.getMessageListener())
+				.onMessageBatch(messages, null);
+		assertThat(outputChannel.receive(0)).isNull();
+		Message<?> received = errorChannel.receive(0);
+		assertThat(received).isNotNull();
+		assertThat(received.getHeaders().get(AmqpMessageHeaderErrorMessageStrategy.AMQP_RAW_MESSAGE)).isNotNull();
+		assertThat(received.getPayload().getClass()).isEqualTo(ListenerExecutionFailedException.class);
+
+		container.setAcknowledgeMode(AcknowledgeMode.MANUAL);
+		adapter.afterPropertiesSet(); // ack mode is now captured during init
+		((ChannelAwareBatchMessageListener) container.getMessageListener())
+				.onMessageBatch(messages, channel);
+		assertThat(outputChannel.receive(0)).isNull();
+		received = errorChannel.receive(0);
+		assertThat(received).isNotNull();
+		assertThat(received.getHeaders().get(AmqpMessageHeaderErrorMessageStrategy.AMQP_RAW_MESSAGE)).isNotNull();
+		assertThat(received.getPayload()).isInstanceOf(ManualAckListenerExecutionFailedException.class);
+		ManualAckListenerExecutionFailedException ex = (ManualAckListenerExecutionFailedException) received
+				.getPayload();
+		assertThat(ex.getChannel()).isEqualTo(channel);
+		assertThat(ex.getDeliveryTag()).isEqualTo(43L);
+	}
+
+	@Test
+	public void testRetryWithinOnMessageAdapterConsumerBatch() {
+		SimpleMessageListenerContainer container = new SimpleMessageListenerContainer(connectionFactory);
+		container.setConsumerBatchEnabled(true);
+		AmqpInboundChannelAdapter adapter = new AmqpInboundChannelAdapter(container);
+		adapter.setOutputChannel(new DirectChannel());
+		adapter.setRetryTemplate(new RetryTemplate());
+		QueueChannel errors = new QueueChannel();
+		ErrorMessageSendingRecoverer recoveryCallback = new ErrorMessageSendingRecoverer(errors);
+		recoveryCallback.setErrorMessageStrategy(new AmqpMessageHeaderErrorMessageStrategy());
+		adapter.setRecoveryCallback(recoveryCallback);
+		adapter.afterPropertiesSet();
+		ChannelAwareBatchMessageListener listener = (ChannelAwareBatchMessageListener) container.getMessageListener();
+		MessageProperties messageProperties = new MessageProperties();
+		messageProperties.setContentType("text/plain");
+		messageProperties.setDeliveryTag(42L);
+		List<org.springframework.amqp.core.Message> messages = new ArrayList<>();
+		messages.add(new org.springframework.amqp.core.Message("test1".getBytes(), messageProperties));
+		messageProperties = new MessageProperties();
+		messageProperties.setContentType("text/plain");
+		messageProperties.setDeliveryTag(43L);
+		messages.add(new org.springframework.amqp.core.Message("test2".getBytes(), messageProperties));
+		listener.onMessageBatch(messages, null);
+		Message<?> errorMessage = errors.receive(0);
+		assertThat(errorMessage).isNotNull();
+		assertThat(errorMessage.getPayload()).isInstanceOf(MessagingException.class);
+		MessagingException payload = (MessagingException) errorMessage.getPayload();
+		assertThat(payload.getMessage()).contains("Dispatcher has no");
+		assertThat(StaticMessageHeaderAccessor.getDeliveryAttempt(payload.getFailedMessage()).get()).isEqualTo(3);
+		@SuppressWarnings("unchecked")
+		List<org.springframework.amqp.core.Message> amqpMessages = errorMessage.getHeaders()
+				.get(AmqpMessageHeaderErrorMessageStrategy.AMQP_RAW_MESSAGE,
+						List.class);
+		assertThat(amqpMessages).isNotNull();
+		assertThat(amqpMessages).hasSize(2);
+		@SuppressWarnings("unchecked")
+		List<Message<?>> msgs = (List<Message<?>>) payload.getFailedMessage().getPayload();
+		assertThat(msgs).hasSize(2);
+		assertThat(msgs).extracting(msg -> StaticMessageHeaderAccessor.getDeliveryAttempt(msg).get())
+				.contains(3, 3);
+		assertThat(msgs).extracting(msg -> msg.getHeaders().get(AmqpHeaders.DELIVERY_TAG, Long.class))
+				.contains(42L, 43L);
+		assertThat(errors.receive(0)).isNull();
+	}
+
+	@Test
+	public void testRetryWithMessageRecovererOnMessageAdapterConsumerBatch() throws InterruptedException {
+		SimpleMessageListenerContainer container = new SimpleMessageListenerContainer(connectionFactory);
+		container.setConsumerBatchEnabled(true);
+		AmqpInboundChannelAdapter adapter = new AmqpInboundChannelAdapter(container);
+		adapter.setOutputChannel(new DirectChannel());
+		adapter.setRetryTemplate(new RetryTemplate());
+		AtomicReference<List<org.springframework.amqp.core.Message>> recoveredMessages = new AtomicReference<>();
+		AtomicReference<Throwable> recoveredError = new AtomicReference<>();
+		CountDownLatch recoveredLatch = new CountDownLatch(1);
+		adapter.setMessageRecoverer((MessageBatchRecoverer) (messages, cause) -> {
+			recoveredMessages.set(messages);
+			recoveredError.set(cause);
+			recoveredLatch.countDown();
+		});
+		adapter.afterPropertiesSet();
+		ChannelAwareBatchMessageListener listener = (ChannelAwareBatchMessageListener) container.getMessageListener();
+		MessageProperties messageProperties = new MessageProperties();
+		messageProperties.setContentType("text/plain");
+		messageProperties.setDeliveryTag(42L);
+		List<org.springframework.amqp.core.Message> messages = new ArrayList<>();
+		messages.add(new org.springframework.amqp.core.Message("test1".getBytes(), messageProperties));
+		messageProperties = new MessageProperties();
+		messageProperties.setContentType("text/plain");
+		messageProperties.setDeliveryTag(43L);
+		messages.add(new org.springframework.amqp.core.Message("test2".getBytes(), messageProperties));
+		listener.onMessageBatch(messages, null);
+
+		assertThat(recoveredLatch.await(10, TimeUnit.SECONDS)).isTrue();
+
+		assertThat(recoveredError.get())
+				.isInstanceOf(MessagingException.class)
+				.extracting(Throwable::getMessage, InstanceOfAssertFactories.STRING)
+				.contains("Dispatcher has no");
+
+		assertThat(recoveredMessages.get()).isSameAs(messages);
+	}
+
+	public record Foo(String bar) {
+
 	}
 
 }

--- a/spring-integration-amqp/src/test/java/org/springframework/integration/amqp/channel/DispatcherHasNoSubscribersTests.java
+++ b/spring-integration-amqp/src/test/java/org/springframework/integration/amqp/channel/DispatcherHasNoSubscribersTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2024 the original author or authors.
+ * Copyright 2002-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -14,754 +14,125 @@
  * limitations under the License.
  */
 
-package org.springframework.integration.amqp.inbound;
+package org.springframework.integration.amqp.channel;
 
 import java.util.ArrayList;
 import java.util.List;
-import java.util.Map;
-import java.util.concurrent.CountDownLatch;
-import java.util.concurrent.TimeUnit;
-import java.util.concurrent.atomic.AtomicReference;
 
+import com.rabbitmq.client.AMQP.Queue.DeclareOk;
 import com.rabbitmq.client.Channel;
-import org.assertj.core.api.InstanceOfAssertFactories;
+import org.apache.commons.logging.Log;
 import org.junit.jupiter.api.Test;
-import org.mockito.Mockito;
 
-import org.springframework.amqp.core.AcknowledgeMode;
-import org.springframework.amqp.core.MessageProperties;
-import org.springframework.amqp.rabbit.batch.MessageBatch;
-import org.springframework.amqp.rabbit.batch.SimpleBatchingStrategy;
+import org.springframework.amqp.core.AmqpTemplate;
+import org.springframework.amqp.core.Message;
+import org.springframework.amqp.core.MessageListener;
 import org.springframework.amqp.rabbit.connection.Connection;
 import org.springframework.amqp.rabbit.connection.ConnectionFactory;
-import org.springframework.amqp.rabbit.core.RabbitTemplate;
-import org.springframework.amqp.rabbit.listener.AbstractMessageListenerContainer;
 import org.springframework.amqp.rabbit.listener.SimpleMessageListenerContainer;
-import org.springframework.amqp.rabbit.listener.api.ChannelAwareBatchMessageListener;
-import org.springframework.amqp.rabbit.listener.api.ChannelAwareMessageListener;
-import org.springframework.amqp.rabbit.retry.MessageBatchRecoverer;
-import org.springframework.amqp.rabbit.support.ListenerExecutionFailedException;
-import org.springframework.amqp.support.AmqpHeaders;
-import org.springframework.amqp.support.converter.Jackson2JsonMessageConverter;
-import org.springframework.amqp.support.converter.MessageConversionException;
-import org.springframework.amqp.support.converter.MessageConverter;
-import org.springframework.amqp.support.converter.SimpleMessageConverter;
+import org.springframework.beans.DirectFieldAccessor;
 import org.springframework.beans.factory.BeanFactory;
-import org.springframework.integration.StaticMessageHeaderAccessor;
-import org.springframework.integration.amqp.inbound.AmqpInboundChannelAdapter.BatchMode;
-import org.springframework.integration.amqp.support.AmqpMessageHeaderErrorMessageStrategy;
-import org.springframework.integration.amqp.support.DefaultAmqpHeaderMapper;
-import org.springframework.integration.amqp.support.ManualAckListenerExecutionFailedException;
-import org.springframework.integration.channel.DirectChannel;
-import org.springframework.integration.channel.QueueChannel;
-import org.springframework.integration.handler.advice.ErrorMessageSendingRecoverer;
-import org.springframework.integration.json.JsonToObjectTransformer;
-import org.springframework.integration.json.ObjectToJsonTransformer;
-import org.springframework.integration.mapping.support.JsonHeaders;
-import org.springframework.integration.support.MessageBuilder;
-import org.springframework.integration.transformer.MessageTransformingHandler;
-import org.springframework.integration.transformer.Transformer;
-import org.springframework.messaging.Message;
-import org.springframework.messaging.MessagingException;
-import org.springframework.messaging.PollableChannel;
-import org.springframework.messaging.support.GenericMessage;
-import org.springframework.retry.support.RetryTemplate;
+import org.springframework.integration.test.util.TestUtils;
+import org.springframework.messaging.MessageDeliveryException;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.assertThatIllegalArgumentException;
-import static org.assertj.core.api.Assertions.assertThatIllegalStateException;
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyBoolean;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.isNull;
-import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.when;
 
 /**
- * @author Artem Bilan
  * @author Gary Russell
+ * @author Artem Bilan
  *
- * @since 3.0
+ * @since 2.1
+ *
  */
-public class InboundEndpointTests {
+public class DispatcherHasNoSubscribersTests {
 	final ConnectionFactory connectionFactory = mock(ConnectionFactory.class);
-	final Channel rabbitChannel = mock(Channel.class);
-	final Channel channel = mock(Channel.class);
 	final Connection connection = mock(Connection.class);
-	
 	@Test
-	public void testInt2809JavaTypePropertiesToAmqp() throws Exception {
-		doAnswer(invocation -> mock(Channel.class)).when(connection).createChannel(anyBoolean());
+	public void testPtP() throws Exception {
+		final Channel channel = mock(Channel.class);
+		DeclareOk declareOk = mock(DeclareOk.class);
+		when(declareOk.getQueue()).thenReturn("noSubscribersChannel");
+		when(channel.queueDeclare(anyString(), anyBoolean(), anyBoolean(), anyBoolean(), isNull()))
+				.thenReturn(declareOk);
+		doAnswer(invocation -> channel).when(connection).createChannel(anyBoolean());
 		when(connectionFactory.createConnection()).thenReturn(connection);
 		SimpleMessageListenerContainer container = new SimpleMessageListenerContainer();
 		container.setConnectionFactory(connectionFactory);
-		container.setAcknowledgeMode(AcknowledgeMode.MANUAL);
+		AmqpTemplate amqpTemplate = mock(AmqpTemplate.class);
 
-		AmqpInboundChannelAdapter adapter = new AmqpInboundChannelAdapter(container);
-		adapter.setMessageConverter(new Jackson2JsonMessageConverter());
+		PointToPointSubscribableAmqpChannel amqpChannel =
+				new PointToPointSubscribableAmqpChannel("noSubscribersChannel", container, amqpTemplate);
+		amqpChannel.setBeanName("noSubscribersChannel");
+		amqpChannel.setBeanFactory(mock(BeanFactory.class));
+		amqpChannel.afterPropertiesSet();
 
-		PollableChannel channel = new QueueChannel();
+		MessageListener listener = container.getMessageListener();
 
-		adapter.setOutputChannel(channel);
-		adapter.setBeanFactory(mock(BeanFactory.class));
-		adapter.setBindSourceMessage(true);
-		adapter.afterPropertiesSet();
-
-		Object payload = new Foo("bar1");
-
-		Transformer objectToJsonTransformer = new ObjectToJsonTransformer();
-		Message<?> jsonMessage = objectToJsonTransformer.transform(new GenericMessage<>(payload));
-
-		MessageProperties amqpMessageProperties = new MessageProperties();
-		amqpMessageProperties.setDeliveryTag(123L);
-		org.springframework.amqp.core.Message amqpMessage =
-				new SimpleMessageConverter().toMessage(jsonMessage.getPayload(), amqpMessageProperties);
-		DefaultAmqpHeaderMapper.inboundMapper().fromHeadersToRequest(jsonMessage.getHeaders(), amqpMessageProperties);
-
-		ChannelAwareMessageListener listener = (ChannelAwareMessageListener) container.getMessageListener();
-		listener.onMessage(amqpMessage, rabbitChannel);
-
-		Message<?> result = channel.receive(1000);
-		assertThat(result.getPayload()).isEqualTo(payload);
-
-		assertThat(result.getHeaders().get(AmqpHeaders.CHANNEL)).isSameAs(rabbitChannel);
-		assertThat(result.getHeaders().get(AmqpHeaders.DELIVERY_TAG)).isEqualTo(123L);
-		org.springframework.amqp.core.Message sourceData = StaticMessageHeaderAccessor.getSourceData(result);
-		assertThat(sourceData).isSameAs(amqpMessage);
+		assertThatExceptionOfType(MessageDeliveryException.class)
+				.isThrownBy(() -> listener.onMessage(new Message("Hello world!".getBytes())))
+				.withMessageContaining("Dispatcher has no subscribers for amqp-channel 'noSubscribersChannel'.");
 	}
 
 	@Test
-	public void testInt2809JavaTypePropertiesFromAmqp() throws Exception {
-		doAnswer(invocation -> mock(Channel.class)).when(connection).createChannel(anyBoolean());
+	public void testPubSub() {
+		final Channel channel = mock(Channel.class);
+		doAnswer(invocation -> channel).when(connection).createChannel(anyBoolean());
 		when(connectionFactory.createConnection()).thenReturn(connection);
 		SimpleMessageListenerContainer container = new SimpleMessageListenerContainer();
 		container.setConnectionFactory(connectionFactory);
+		AmqpTemplate amqpTemplate = mock(AmqpTemplate.class);
+		PublishSubscribeAmqpChannel amqpChannel =
+				new PublishSubscribeAmqpChannel("noSubscribersChannel", container, amqpTemplate);
+		amqpChannel.setBeanName("noSubscribersChannel");
+		amqpChannel.setBeanFactory(mock(BeanFactory.class));
+		amqpChannel.afterPropertiesSet();
 
-		AmqpInboundChannelAdapter adapter = new AmqpInboundChannelAdapter(container);
-
-		PollableChannel channel = new QueueChannel();
-
-		adapter.setOutputChannel(channel);
-		adapter.setBeanFactory(mock(BeanFactory.class));
-		adapter.afterPropertiesSet();
-
-		Object payload = new Foo("bar1");
-
-		MessageProperties amqpMessageProperties = new MessageProperties();
-		org.springframework.amqp.core.Message amqpMessage =
-				new Jackson2JsonMessageConverter().toMessage(payload, amqpMessageProperties);
-
-		ChannelAwareMessageListener listener = (ChannelAwareMessageListener) container.getMessageListener();
-		listener.onMessage(amqpMessage, null);
-
-		Message<?> receive = channel.receive(1000);
-
-		Message<?> result = new JsonToObjectTransformer().transform(receive);
-
-		assertThat(result.getPayload()).isEqualTo(payload);
-		org.springframework.amqp.core.Message sourceData = StaticMessageHeaderAccessor.getSourceData(result);
-		assertThat(sourceData).isNull();
+		List<String> logList = insertMockLoggerInListener(amqpChannel);
+		MessageListener listener = container.getMessageListener();
+		listener.onMessage(new Message("Hello world!".getBytes()));
+		verifyLogReceived(logList);
 	}
 
-	@Test
-	public void testMessageConverterJsonHeadersHavePrecedenceOverMessageHeaders() throws Exception {
-		doAnswer(invocation -> mock(Channel.class)).when(connection).createChannel(anyBoolean());
-		when(connectionFactory.createConnection()).thenReturn(connection);
-		SimpleMessageListenerContainer container = new SimpleMessageListenerContainer();
-		container.setConnectionFactory(connectionFactory);
-		container.setAcknowledgeMode(AcknowledgeMode.MANUAL);
-
-		DirectChannel channel = new DirectChannel();
-
-		channel.subscribe(new MessageTransformingHandler(message -> {
-			assertThat(message.getHeaders().get(AmqpHeaders.CHANNEL)).isSameAs(rabbitChannel);
-			assertThat(message.getHeaders().get(AmqpHeaders.DELIVERY_TAG)).isEqualTo(123L);
-			return MessageBuilder.fromMessage(message)
-					.setHeader(JsonHeaders.TYPE_ID, "foo")
-					.setHeader(JsonHeaders.CONTENT_TYPE_ID, "bar")
-					.setHeader(JsonHeaders.KEY_TYPE_ID, "baz")
-					.build();
-		}));
-
-		RabbitTemplate rabbitTemplate = spy(new RabbitTemplate());
-		rabbitTemplate.setMessageConverter(new Jackson2JsonMessageConverter());
-
-		CountDownLatch sendLatch = new CountDownLatch(1);
-
-		Mockito.doAnswer(invocation -> {
-					org.springframework.amqp.core.Message message =
-							invocation.getArgument(2);
-					Map<String, Object> headers = message.getMessageProperties().getHeaders();
-					assertThat(headers.containsKey(JsonHeaders.TYPE_ID.replaceFirst(JsonHeaders.PREFIX, ""))).isTrue();
-					assertThat(headers.get(JsonHeaders.TYPE_ID.replaceFirst(JsonHeaders.PREFIX, ""))).isNotEqualTo("foo");
-					assertThat(headers.containsKey(JsonHeaders.CONTENT_TYPE_ID.replaceFirst(JsonHeaders.PREFIX, ""))).isFalse();
-					assertThat(headers.containsKey(JsonHeaders.KEY_TYPE_ID.replaceFirst(JsonHeaders.PREFIX, ""))).isFalse();
-					assertThat(headers.containsKey(JsonHeaders.TYPE_ID)).isFalse();
-					assertThat(headers.containsKey(JsonHeaders.KEY_TYPE_ID)).isFalse();
-					assertThat(headers.containsKey(JsonHeaders.CONTENT_TYPE_ID)).isFalse();
-					sendLatch.countDown();
-					return null;
-				}).when(rabbitTemplate)
-				.send(anyString(), anyString(), any(org.springframework.amqp.core.Message.class), isNull());
-
-		AmqpInboundGateway gateway = new AmqpInboundGateway(container, rabbitTemplate);
-		gateway.setMessageConverter(new Jackson2JsonMessageConverter());
-		gateway.setRequestChannel(channel);
-		gateway.setBeanFactory(mock(BeanFactory.class));
-		gateway.setDefaultReplyTo("foo");
-		gateway.setReplyHeadersMappedLast(true);
-		gateway.afterPropertiesSet();
-
-		Object payload = new Foo("bar1");
-
-		MessageProperties amqpMessageProperties = new MessageProperties();
-		amqpMessageProperties.setDeliveryTag(123L);
-		org.springframework.amqp.core.Message amqpMessage =
-				new Jackson2JsonMessageConverter().toMessage(payload, amqpMessageProperties);
-
-		ChannelAwareMessageListener listener = (ChannelAwareMessageListener) container.getMessageListener();
-		listener.onMessage(amqpMessage, rabbitChannel);
-
-		assertThat(sendLatch.await(10, TimeUnit.SECONDS)).isTrue();
-	}
-
-	@Test
-	public void testAdapterConversionError() throws Exception {
-		doAnswer(invocation -> mock(Channel.class)).when(connection).createChannel(anyBoolean());
-		when(connectionFactory.createConnection()).thenReturn(connection);
-		SimpleMessageListenerContainer container = new SimpleMessageListenerContainer();
-		container.setConnectionFactory(connectionFactory);
-		AmqpInboundChannelAdapter adapter = new AmqpInboundChannelAdapter(container);
-		QueueChannel outputChannel = new QueueChannel();
-		adapter.setOutputChannel(outputChannel);
-		QueueChannel errorChannel = new QueueChannel();
-		adapter.setErrorChannel(errorChannel);
-		adapter.setMessageConverter(new SimpleMessageConverter() {
-
-			@Override
-			public Object fromMessage(org.springframework.amqp.core.Message message) throws MessageConversionException {
-				throw new MessageConversionException("intended");
+	private static List<String> insertMockLoggerInListener(PublishSubscribeAmqpChannel channel) {
+		SimpleMessageListenerContainer container =
+				TestUtils.getPropertyValue(channel, "container", SimpleMessageListenerContainer.class);
+		Log logger = mock(Log.class);
+		final ArrayList<String> logList = new ArrayList<>();
+		doAnswer(invocation -> {
+			String message = invocation.getArgument(0);
+			if (message.startsWith("Dispatcher has no subscribers")) {
+				logList.add(message);
 			}
-
-		});
-		adapter.afterPropertiesSet();
-		org.springframework.amqp.core.Message message = mock(org.springframework.amqp.core.Message.class);
-		MessageProperties props = new MessageProperties();
-		props.setDeliveryTag(42L);
-		given(message.getMessageProperties()).willReturn(props);
-		((ChannelAwareMessageListener) container.getMessageListener())
-				.onMessage(message, null);
-		assertThat(outputChannel.receive(0)).isNull();
-		Message<?> received = errorChannel.receive(0);
-		assertThat(received).isNotNull();
-		assertThat(received.getHeaders().get(AmqpMessageHeaderErrorMessageStrategy.AMQP_RAW_MESSAGE)).isNotNull();
-		assertThat(received.getPayload().getClass()).isEqualTo(ListenerExecutionFailedException.class);
-
-		container.setAcknowledgeMode(AcknowledgeMode.MANUAL);
-		adapter.afterPropertiesSet(); // ack mode is now captured during init
-		((ChannelAwareMessageListener) container.getMessageListener())
-				.onMessage(message, channel);
-		assertThat(outputChannel.receive(0)).isNull();
-		received = errorChannel.receive(0);
-		assertThat(received).isNotNull();
-		assertThat(received.getHeaders().get(AmqpMessageHeaderErrorMessageStrategy.AMQP_RAW_MESSAGE)).isNotNull();
-		assertThat(received.getPayload()).isInstanceOf(ManualAckListenerExecutionFailedException.class);
-		ManualAckListenerExecutionFailedException ex = (ManualAckListenerExecutionFailedException) received
-				.getPayload();
-		assertThat(ex.getChannel()).isEqualTo(channel);
-		assertThat(ex.getDeliveryTag()).isEqualTo(props.getDeliveryTag());
+			return null;
+		}).when(logger).warn(anyString(), any(Exception.class));
+		when(logger.isWarnEnabled()).thenReturn(true);
+		Object listener = container.getMessageListener();
+		DirectFieldAccessor dfa = new DirectFieldAccessor(listener);
+		dfa.setPropertyValue("logger", logger);
+		return logList;
 	}
 
-	@Test
-	public void testGatewayConversionError() throws Exception {
-		doAnswer(invocation -> mock(Channel.class)).when(connection).createChannel(anyBoolean());
-		when(connectionFactory.createConnection()).thenReturn(connection);
-		SimpleMessageListenerContainer container = new SimpleMessageListenerContainer();
-		container.setConnectionFactory(connectionFactory);
-		AmqpInboundGateway adapter = new AmqpInboundGateway(container);
-		QueueChannel outputChannel = new QueueChannel();
-		adapter.setRequestChannel(outputChannel);
-		QueueChannel errorChannel = new QueueChannel();
-		adapter.setErrorChannel(errorChannel);
-		adapter.setMessageConverter(new MessageConverter() {
-
-			@Override
-			public org.springframework.amqp.core.Message toMessage(Object object, MessageProperties messageProperties)
-					throws MessageConversionException {
-				throw new MessageConversionException("intended");
+	private static void verifyLogReceived(final List<String> logList) {
+		assertThat(logList.size() > 0).as("Failed to get expected exception").isTrue();
+		boolean expectedExceptionFound = false;
+		while (logList.size() > 0) {
+			String message = logList.remove(0);
+			assertThat(message).as("Failed to get expected exception").isNotNull();
+			if (message.startsWith("Dispatcher has no subscribers")) {
+				expectedExceptionFound = true;
+				assertThat(message).contains("Dispatcher has no subscribers for amqp-channel 'noSubscribersChannel'.");
+				break;
 			}
-
-			@Override
-			public Object fromMessage(org.springframework.amqp.core.Message message) throws MessageConversionException {
-				throw new MessageConversionException("intended");
-			}
-
-		});
-		adapter.afterPropertiesSet();
-		org.springframework.amqp.core.Message message = mock(org.springframework.amqp.core.Message.class);
-		MessageProperties props = new MessageProperties();
-		props.setDeliveryTag(42L);
-		given(message.getMessageProperties()).willReturn(props);
-		((ChannelAwareMessageListener) container.getMessageListener())
-				.onMessage(message, null);
-		assertThat(outputChannel.receive(0)).isNull();
-		Message<?> received = errorChannel.receive(0);
-		assertThat(received).isNotNull();
-		assertThat(received.getHeaders().get(AmqpMessageHeaderErrorMessageStrategy.AMQP_RAW_MESSAGE)).isNotNull();
-
-		container.setAcknowledgeMode(AcknowledgeMode.MANUAL);
-		((ChannelAwareMessageListener) container.getMessageListener())
-				.onMessage(message, channel);
-		assertThat(outputChannel.receive(0)).isNull();
-		received = errorChannel.receive(0);
-		assertThat(received).isNotNull();
-		assertThat(received.getHeaders().get(AmqpMessageHeaderErrorMessageStrategy.AMQP_RAW_MESSAGE)).isNotNull();
-		assertThat(received.getPayload()).isInstanceOf(ManualAckListenerExecutionFailedException.class);
-		ManualAckListenerExecutionFailedException ex = (ManualAckListenerExecutionFailedException) received
-				.getPayload();
-		assertThat(ex.getChannel()).isEqualTo(channel);
-		assertThat(ex.getDeliveryTag()).isEqualTo(props.getDeliveryTag());
-	}
-
-	@Test
-	public void testRetryWithinOnMessageAdapter() throws Exception {
-		AbstractMessageListenerContainer container = new SimpleMessageListenerContainer(connectionFactory);
-		AmqpInboundChannelAdapter adapter = new AmqpInboundChannelAdapter(container);
-		adapter.setOutputChannel(new DirectChannel());
-		adapter.setRetryTemplate(new RetryTemplate());
-		QueueChannel errors = new QueueChannel();
-		ErrorMessageSendingRecoverer recoveryCallback = new ErrorMessageSendingRecoverer(errors);
-		recoveryCallback.setErrorMessageStrategy(new AmqpMessageHeaderErrorMessageStrategy());
-		adapter.setRecoveryCallback(recoveryCallback);
-		adapter.afterPropertiesSet();
-		ChannelAwareMessageListener listener = (ChannelAwareMessageListener) container.getMessageListener();
-		listener.onMessage(org.springframework.amqp.core.MessageBuilder.withBody("foo".getBytes())
-				.andProperties(new MessageProperties()).build(), null);
-		Message<?> errorMessage = errors.receive(0);
-		assertThat(errorMessage).isNotNull();
-		assertThat(errorMessage.getPayload()).isInstanceOf(MessagingException.class);
-		MessagingException payload = (MessagingException) errorMessage.getPayload();
-		assertThat(payload.getMessage()).contains("Dispatcher has no");
-		assertThat(StaticMessageHeaderAccessor.getDeliveryAttempt(payload.getFailedMessage()).get()).isEqualTo(3);
-		org.springframework.amqp.core.Message amqpMessage = errorMessage.getHeaders()
-				.get(AmqpMessageHeaderErrorMessageStrategy.AMQP_RAW_MESSAGE,
-						org.springframework.amqp.core.Message.class);
-		assertThat(amqpMessage).isNotNull();
-		assertThat(errors.receive(0)).isNull();
-	}
-
-	@Test
-	public void testRetryWithMessageRecovererOnMessageAdapter() throws Exception {
-		AbstractMessageListenerContainer container = new SimpleMessageListenerContainer(connectionFactory);
-		AmqpInboundChannelAdapter adapter = new AmqpInboundChannelAdapter(container);
-		adapter.setOutputChannel(new DirectChannel());
-		adapter.setRetryTemplate(new RetryTemplate());
-		AtomicReference<org.springframework.amqp.core.Message> recoveredMessage = new AtomicReference<>();
-		AtomicReference<Throwable> recoveredError = new AtomicReference<>();
-		CountDownLatch recoveredLatch = new CountDownLatch(1);
-		adapter.setMessageRecoverer((message, cause) -> {
-			recoveredMessage.set(message);
-			recoveredError.set(cause);
-			recoveredLatch.countDown();
-		});
-		adapter.afterPropertiesSet();
-		ChannelAwareMessageListener listener = (ChannelAwareMessageListener) container.getMessageListener();
-		org.springframework.amqp.core.Message amqpMessage =
-				org.springframework.amqp.core.MessageBuilder.withBody("foo".getBytes())
-						.andProperties(new MessageProperties())
-						.build();
-		listener.onMessage(amqpMessage, null);
-
-		assertThat(recoveredLatch.await(10, TimeUnit.SECONDS)).isTrue();
-
-		assertThat(recoveredError.get())
-				.isInstanceOf(MessagingException.class)
-				.extracting(Throwable::getMessage, InstanceOfAssertFactories.STRING)
-				.contains("Dispatcher has no");
-
-		assertThat(recoveredMessage.get()).isSameAs(amqpMessage);
-	}
-
-	@Test
-	public void testRetryWithinOnMessageGateway() throws Exception {
-		AbstractMessageListenerContainer container = new SimpleMessageListenerContainer(connectionFactory);
-		AmqpInboundGateway adapter = new AmqpInboundGateway(container);
-		adapter.setRequestChannel(new DirectChannel());
-		adapter.setRetryTemplate(new RetryTemplate());
-		QueueChannel errors = new QueueChannel();
-		ErrorMessageSendingRecoverer recoveryCallback = new ErrorMessageSendingRecoverer(errors);
-		recoveryCallback.setErrorMessageStrategy(new AmqpMessageHeaderErrorMessageStrategy());
-		adapter.setRecoveryCallback(recoveryCallback);
-		adapter.afterPropertiesSet();
-		ChannelAwareMessageListener listener = (ChannelAwareMessageListener) container.getMessageListener();
-		listener.onMessage(org.springframework.amqp.core.MessageBuilder.withBody("foo".getBytes())
-				.andProperties(new MessageProperties()).build(), null);
-		Message<?> errorMessage = errors.receive(0);
-		assertThat(errorMessage).isNotNull();
-		assertThat(errorMessage.getPayload()).isInstanceOf(MessagingException.class);
-		MessagingException payload = (MessagingException) errorMessage.getPayload();
-		assertThat(payload.getMessage()).contains("Dispatcher has no");
-		assertThat(StaticMessageHeaderAccessor.getDeliveryAttempt(payload.getFailedMessage()).get()).isEqualTo(3);
-		org.springframework.amqp.core.Message amqpMessage = errorMessage.getHeaders()
-				.get(AmqpMessageHeaderErrorMessageStrategy.AMQP_RAW_MESSAGE,
-						org.springframework.amqp.core.Message.class);
-		assertThat(amqpMessage).isNotNull();
-		assertThat(errors.receive(0)).isNull();
-	}
-
-	@Test
-	public void testRetryWithMessageRecovererOnMessageGateway() throws Exception {
-		AbstractMessageListenerContainer container = new SimpleMessageListenerContainer(connectionFactory);
-		AmqpInboundGateway adapter = new AmqpInboundGateway(container);
-		adapter.setRequestChannel(new DirectChannel());
-		adapter.setRetryTemplate(new RetryTemplate());
-		AtomicReference<org.springframework.amqp.core.Message> recoveredMessage = new AtomicReference<>();
-		AtomicReference<Throwable> recoveredError = new AtomicReference<>();
-		CountDownLatch recoveredLatch = new CountDownLatch(1);
-		adapter.setMessageRecoverer((message, cause) -> {
-			recoveredMessage.set(message);
-			recoveredError.set(cause);
-			recoveredLatch.countDown();
-		});
-		adapter.afterPropertiesSet();
-		ChannelAwareMessageListener listener = (ChannelAwareMessageListener) container.getMessageListener();
-		org.springframework.amqp.core.Message amqpMessage =
-				org.springframework.amqp.core.MessageBuilder.withBody("foo".getBytes())
-						.andProperties(new MessageProperties())
-						.build();
-		listener.onMessage(amqpMessage, null);
-
-		assertThat(recoveredLatch.await(10, TimeUnit.SECONDS)).isTrue();
-
-		assertThat(recoveredError.get())
-				.isInstanceOf(MessagingException.class)
-				.extracting(Throwable::getMessage, InstanceOfAssertFactories.STRING)
-				.contains("Dispatcher has no");
-
-		assertThat(recoveredMessage.get()).isSameAs(amqpMessage);
-	}
-
-	@SuppressWarnings({"unchecked"})
-	@Test
-	public void testBatchAdapter() throws Exception {
-		SimpleMessageListenerContainer container = new SimpleMessageListenerContainer(mock(ConnectionFactory.class));
-		container.setDeBatchingEnabled(false);
-		AmqpInboundChannelAdapter adapter = new AmqpInboundChannelAdapter(container);
-		QueueChannel out = new QueueChannel();
-		adapter.setOutputChannel(out);
-		adapter.afterPropertiesSet();
-		ChannelAwareMessageListener listener = (ChannelAwareMessageListener) container.getMessageListener();
-		SimpleBatchingStrategy bs = new SimpleBatchingStrategy(2, 10_000, 10_000L);
-		MessageProperties messageProperties = new MessageProperties();
-		messageProperties.setContentType("text/plain");
-		org.springframework.amqp.core.Message message =
-				new org.springframework.amqp.core.Message("test1".getBytes(), messageProperties);
-		bs.addToBatch("foo", "bar", message);
-		message = new org.springframework.amqp.core.Message("test2".getBytes(), messageProperties);
-		MessageBatch batched = bs.addToBatch("foo", "bar", message);
-		listener.onMessage(batched.getMessage(), null);
-		Message<?> received = out.receive(0);
-		assertThat(received).isNotNull();
-		assertThat(((List<String>) received.getPayload())).contains("test1", "test2");
-	}
-
-	@SuppressWarnings({"unchecked"})
-	@Test
-	public void testBatchGateway() throws Exception {
-		SimpleMessageListenerContainer container = new SimpleMessageListenerContainer(mock(ConnectionFactory.class));
-		container.setDeBatchingEnabled(false);
-		AmqpInboundGateway gateway = new AmqpInboundGateway(container);
-		QueueChannel out = new QueueChannel();
-		gateway.setRequestChannel(out);
-		gateway.setBindSourceMessage(true);
-		gateway.setReplyTimeout(0);
-		gateway.afterPropertiesSet();
-		ChannelAwareMessageListener listener = (ChannelAwareMessageListener) container.getMessageListener();
-		SimpleBatchingStrategy bs = new SimpleBatchingStrategy(2, 10_000, 10_000L);
-		MessageProperties messageProperties = new MessageProperties();
-		messageProperties.setContentType("text/plain");
-		org.springframework.amqp.core.Message message =
-				new org.springframework.amqp.core.Message("test1".getBytes(), messageProperties);
-		bs.addToBatch("foo", "bar", message);
-		message = new org.springframework.amqp.core.Message("test2".getBytes(), messageProperties);
-		MessageBatch batched = bs.addToBatch("foo", "bar", message);
-		listener.onMessage(batched.getMessage(), null);
-		Message<?> received = out.receive(0);
-		assertThat(received).isNotNull();
-		assertThat(((List<String>) received.getPayload())).contains("test1", "test2");
-		org.springframework.amqp.core.Message sourceData = StaticMessageHeaderAccessor.getSourceData(received);
-		assertThat(sourceData).isSameAs(batched.getMessage());
-	}
-
-	@SuppressWarnings({"unchecked"})
-	@Test
-	public void testConsumerBatchExtract() {
-		SimpleMessageListenerContainer container = new SimpleMessageListenerContainer(mock(ConnectionFactory.class));
-		container.setConsumerBatchEnabled(true);
-		AmqpInboundChannelAdapter adapter = new AmqpInboundChannelAdapter(container);
-		QueueChannel out = new QueueChannel();
-		adapter.setOutputChannel(out);
-		adapter.setBatchMode(BatchMode.EXTRACT_PAYLOADS_WITH_HEADERS);
-		adapter.afterPropertiesSet();
-		ChannelAwareBatchMessageListener listener = (ChannelAwareBatchMessageListener) container.getMessageListener();
-		MessageProperties messageProperties = new MessageProperties();
-		messageProperties.setContentType("text/plain");
-		List<org.springframework.amqp.core.Message> messages = new ArrayList<>();
-		messages.add(new org.springframework.amqp.core.Message("test1".getBytes(), messageProperties));
-		messages.add(new org.springframework.amqp.core.Message("test2".getBytes(), messageProperties));
-		listener.onMessageBatch(messages, null);
-		Message<?> received = out.receive(0);
-		assertThat(received).isNotNull();
-		assertThat(((List<String>) received.getPayload())).contains("test1", "test2");
-		assertThat(received.getHeaders().get(AmqpInboundChannelAdapter.CONSOLIDATED_HEADERS, List.class))
-				.hasSize(2);
-	}
-
-	@SuppressWarnings({"unchecked"})
-	@Test
-	public void testConsumerBatch() {
-		SimpleMessageListenerContainer container = new SimpleMessageListenerContainer(mock(ConnectionFactory.class));
-		container.setConsumerBatchEnabled(true);
-		AmqpInboundChannelAdapter adapter = new AmqpInboundChannelAdapter(container);
-		QueueChannel out = new QueueChannel();
-		adapter.setOutputChannel(out);
-		adapter.afterPropertiesSet();
-		ChannelAwareBatchMessageListener listener = (ChannelAwareBatchMessageListener) container.getMessageListener();
-		MessageProperties messageProperties = new MessageProperties();
-		messageProperties.setContentType("text/plain");
-		List<org.springframework.amqp.core.Message> messages = new ArrayList<>();
-		messages.add(new org.springframework.amqp.core.Message("test1".getBytes(), messageProperties));
-		messages.add(new org.springframework.amqp.core.Message("test2".getBytes(), messageProperties));
-		listener.onMessageBatch(messages, null);
-		Message<?> received = out.receive(0);
-		assertThat(received).isNotNull();
-		assertThat(((List<Message<String>>) received.getPayload()))
-				.extracting(message -> message.getPayload())
-				.contains("test1", "test2");
-	}
-
-	@Test
-	public void testConsumerBatchAndWrongMessageRecoverer() {
-		SimpleMessageListenerContainer container = new SimpleMessageListenerContainer(mock(ConnectionFactory.class));
-		container.setConsumerBatchEnabled(true);
-		AmqpInboundChannelAdapter adapter = new AmqpInboundChannelAdapter(container);
-		adapter.setRetryTemplate(new RetryTemplate());
-		adapter.setMessageRecoverer((message, cause) -> {
-		});
-		assertThatIllegalArgumentException()
-				.isThrownBy(adapter::afterPropertiesSet)
-				.withMessageStartingWith("The 'messageRecoverer' must be an instance of MessageBatchRecoverer " +
-						"when consumer configured for batch mode");
-	}
-
-	@Test
-	public void testExclusiveRecover() {
-		AmqpInboundChannelAdapter adapter = new AmqpInboundChannelAdapter(mock(AbstractMessageListenerContainer.class));
-		adapter.setRetryTemplate(new RetryTemplate());
-		adapter.setMessageRecoverer((message, cause) -> {
-		});
-		adapter.setRecoveryCallback(context -> null);
-		assertThatIllegalStateException()
-				.isThrownBy(adapter::afterPropertiesSet)
-				.withMessageStartingWith("Only one of 'recoveryCallback' or 'messageRecoverer' may be provided, " +
-						"but not both");
-	}
-
-	@Test
-	public void testAdapterConversionErrorConsumerBatchExtract() {
-		doAnswer(invocation -> mock(Channel.class)).when(connection).createChannel(anyBoolean());
-		when(connectionFactory.createConnection()).thenReturn(connection);
-		SimpleMessageListenerContainer container = new SimpleMessageListenerContainer();
-		container.setConnectionFactory(connectionFactory);
-		container.setConsumerBatchEnabled(true);
-		AmqpInboundChannelAdapter adapter = new AmqpInboundChannelAdapter(container);
-		QueueChannel outputChannel = new QueueChannel();
-		adapter.setOutputChannel(outputChannel);
-		QueueChannel errorChannel = new QueueChannel();
-		adapter.setErrorChannel(errorChannel);
-		adapter.setMessageConverter(new SimpleMessageConverter() {
-
-			@Override
-			public Object fromMessage(org.springframework.amqp.core.Message message) throws MessageConversionException {
-				throw new MessageConversionException("intended");
-			}
-
-		});
-		adapter.setBatchMode(BatchMode.EXTRACT_PAYLOADS);
-		adapter.afterPropertiesSet();
-		MessageProperties messageProperties = new MessageProperties();
-		messageProperties.setContentType("text/plain");
-		messageProperties.setDeliveryTag(42L);
-		List<org.springframework.amqp.core.Message> messages = new ArrayList<>();
-		messages.add(new org.springframework.amqp.core.Message("test1".getBytes(), messageProperties));
-		messageProperties = new MessageProperties();
-		messageProperties.setContentType("text/plain");
-		messageProperties.setDeliveryTag(43L);
-		messages.add(new org.springframework.amqp.core.Message("test2".getBytes(), messageProperties));
-		((ChannelAwareBatchMessageListener) container.getMessageListener())
-				.onMessageBatch(messages, null);
-		assertThat(outputChannel.receive(0)).isNull();
-		Message<?> received = errorChannel.receive(0);
-		assertThat(received).isNotNull();
-		assertThat(received.getHeaders().get(AmqpMessageHeaderErrorMessageStrategy.AMQP_RAW_MESSAGE)).isNotNull();
-		assertThat(received.getPayload().getClass()).isEqualTo(ListenerExecutionFailedException.class);
-
-		container.setAcknowledgeMode(AcknowledgeMode.MANUAL);
-		adapter.afterPropertiesSet(); // ack mode is now captured during init
-		((ChannelAwareBatchMessageListener) container.getMessageListener())
-				.onMessageBatch(messages, channel);
-		assertThat(outputChannel.receive(0)).isNull();
-		received = errorChannel.receive(0);
-		assertThat(received).isNotNull();
-		assertThat(received.getHeaders().get(AmqpMessageHeaderErrorMessageStrategy.AMQP_RAW_MESSAGE)).isNotNull();
-		assertThat(received.getPayload()).isInstanceOf(ManualAckListenerExecutionFailedException.class);
-		ManualAckListenerExecutionFailedException ex = (ManualAckListenerExecutionFailedException) received
-				.getPayload();
-		assertThat(ex.getChannel()).isEqualTo(channel);
-		assertThat(ex.getDeliveryTag()).isEqualTo(43L);
-	}
-
-	@Test
-	public void testAdapterConversionErrorConsumerBatch() {
-		doAnswer(invocation -> mock(Channel.class)).when(connection).createChannel(anyBoolean());
-		when(connectionFactory.createConnection()).thenReturn(connection);
-		SimpleMessageListenerContainer container = new SimpleMessageListenerContainer();
-		container.setConnectionFactory(connectionFactory);
-		container.setConsumerBatchEnabled(true);
-		AmqpInboundChannelAdapter adapter = new AmqpInboundChannelAdapter(container);
-		QueueChannel outputChannel = new QueueChannel();
-		adapter.setOutputChannel(outputChannel);
-		QueueChannel errorChannel = new QueueChannel();
-		adapter.setErrorChannel(errorChannel);
-		adapter.setMessageConverter(new SimpleMessageConverter() {
-
-			@Override
-			public Object fromMessage(org.springframework.amqp.core.Message message) throws MessageConversionException {
-				throw new MessageConversionException("intended");
-			}
-
-		});
-		adapter.afterPropertiesSet();
-		MessageProperties messageProperties = new MessageProperties();
-		messageProperties.setContentType("text/plain");
-		messageProperties.setDeliveryTag(42L);
-		List<org.springframework.amqp.core.Message> messages = new ArrayList<>();
-		messages.add(new org.springframework.amqp.core.Message("test1".getBytes(), messageProperties));
-		messageProperties = new MessageProperties();
-		messageProperties.setContentType("text/plain");
-		messageProperties.setDeliveryTag(43L);
-		messages.add(new org.springframework.amqp.core.Message("test2".getBytes(), messageProperties));
-		((ChannelAwareBatchMessageListener) container.getMessageListener())
-				.onMessageBatch(messages, null);
-		assertThat(outputChannel.receive(0)).isNull();
-		Message<?> received = errorChannel.receive(0);
-		assertThat(received).isNotNull();
-		assertThat(received.getHeaders().get(AmqpMessageHeaderErrorMessageStrategy.AMQP_RAW_MESSAGE)).isNotNull();
-		assertThat(received.getPayload().getClass()).isEqualTo(ListenerExecutionFailedException.class);
-
-		container.setAcknowledgeMode(AcknowledgeMode.MANUAL);
-		adapter.afterPropertiesSet(); // ack mode is now captured during init
-		((ChannelAwareBatchMessageListener) container.getMessageListener())
-				.onMessageBatch(messages, channel);
-		assertThat(outputChannel.receive(0)).isNull();
-		received = errorChannel.receive(0);
-		assertThat(received).isNotNull();
-		assertThat(received.getHeaders().get(AmqpMessageHeaderErrorMessageStrategy.AMQP_RAW_MESSAGE)).isNotNull();
-		assertThat(received.getPayload()).isInstanceOf(ManualAckListenerExecutionFailedException.class);
-		ManualAckListenerExecutionFailedException ex = (ManualAckListenerExecutionFailedException) received
-				.getPayload();
-		assertThat(ex.getChannel()).isEqualTo(channel);
-		assertThat(ex.getDeliveryTag()).isEqualTo(43L);
-	}
-
-	@Test
-	public void testRetryWithinOnMessageAdapterConsumerBatch() {
-		SimpleMessageListenerContainer container = new SimpleMessageListenerContainer(connectionFactory);
-		container.setConsumerBatchEnabled(true);
-		AmqpInboundChannelAdapter adapter = new AmqpInboundChannelAdapter(container);
-		adapter.setOutputChannel(new DirectChannel());
-		adapter.setRetryTemplate(new RetryTemplate());
-		QueueChannel errors = new QueueChannel();
-		ErrorMessageSendingRecoverer recoveryCallback = new ErrorMessageSendingRecoverer(errors);
-		recoveryCallback.setErrorMessageStrategy(new AmqpMessageHeaderErrorMessageStrategy());
-		adapter.setRecoveryCallback(recoveryCallback);
-		adapter.afterPropertiesSet();
-		ChannelAwareBatchMessageListener listener = (ChannelAwareBatchMessageListener) container.getMessageListener();
-		MessageProperties messageProperties = new MessageProperties();
-		messageProperties.setContentType("text/plain");
-		messageProperties.setDeliveryTag(42L);
-		List<org.springframework.amqp.core.Message> messages = new ArrayList<>();
-		messages.add(new org.springframework.amqp.core.Message("test1".getBytes(), messageProperties));
-		messageProperties = new MessageProperties();
-		messageProperties.setContentType("text/plain");
-		messageProperties.setDeliveryTag(43L);
-		messages.add(new org.springframework.amqp.core.Message("test2".getBytes(), messageProperties));
-		listener.onMessageBatch(messages, null);
-		Message<?> errorMessage = errors.receive(0);
-		assertThat(errorMessage).isNotNull();
-		assertThat(errorMessage.getPayload()).isInstanceOf(MessagingException.class);
-		MessagingException payload = (MessagingException) errorMessage.getPayload();
-		assertThat(payload.getMessage()).contains("Dispatcher has no");
-		assertThat(StaticMessageHeaderAccessor.getDeliveryAttempt(payload.getFailedMessage()).get()).isEqualTo(3);
-		@SuppressWarnings("unchecked")
-		List<org.springframework.amqp.core.Message> amqpMessages = errorMessage.getHeaders()
-				.get(AmqpMessageHeaderErrorMessageStrategy.AMQP_RAW_MESSAGE,
-						List.class);
-		assertThat(amqpMessages).isNotNull();
-		assertThat(amqpMessages).hasSize(2);
-		@SuppressWarnings("unchecked")
-		List<Message<?>> msgs = (List<Message<?>>) payload.getFailedMessage().getPayload();
-		assertThat(msgs).hasSize(2);
-		assertThat(msgs).extracting(msg -> StaticMessageHeaderAccessor.getDeliveryAttempt(msg).get())
-				.contains(3, 3);
-		assertThat(msgs).extracting(msg -> msg.getHeaders().get(AmqpHeaders.DELIVERY_TAG, Long.class))
-				.contains(42L, 43L);
-		assertThat(errors.receive(0)).isNull();
-	}
-
-	@Test
-	public void testRetryWithMessageRecovererOnMessageAdapterConsumerBatch() throws InterruptedException {
-		SimpleMessageListenerContainer container = new SimpleMessageListenerContainer(connectionFactory);
-		container.setConsumerBatchEnabled(true);
-		AmqpInboundChannelAdapter adapter = new AmqpInboundChannelAdapter(container);
-		adapter.setOutputChannel(new DirectChannel());
-		adapter.setRetryTemplate(new RetryTemplate());
-		AtomicReference<List<org.springframework.amqp.core.Message>> recoveredMessages = new AtomicReference<>();
-		AtomicReference<Throwable> recoveredError = new AtomicReference<>();
-		CountDownLatch recoveredLatch = new CountDownLatch(1);
-		adapter.setMessageRecoverer((MessageBatchRecoverer) (messages, cause) -> {
-			recoveredMessages.set(messages);
-			recoveredError.set(cause);
-			recoveredLatch.countDown();
-		});
-		adapter.afterPropertiesSet();
-		ChannelAwareBatchMessageListener listener = (ChannelAwareBatchMessageListener) container.getMessageListener();
-		MessageProperties messageProperties = new MessageProperties();
-		messageProperties.setContentType("text/plain");
-		messageProperties.setDeliveryTag(42L);
-		List<org.springframework.amqp.core.Message> messages = new ArrayList<>();
-		messages.add(new org.springframework.amqp.core.Message("test1".getBytes(), messageProperties));
-		messageProperties = new MessageProperties();
-		messageProperties.setContentType("text/plain");
-		messageProperties.setDeliveryTag(43L);
-		messages.add(new org.springframework.amqp.core.Message("test2".getBytes(), messageProperties));
-		listener.onMessageBatch(messages, null);
-
-		assertThat(recoveredLatch.await(10, TimeUnit.SECONDS)).isTrue();
-
-		assertThat(recoveredError.get())
-				.isInstanceOf(MessagingException.class)
-				.extracting(Throwable::getMessage, InstanceOfAssertFactories.STRING)
-				.contains("Dispatcher has no");
-
-		assertThat(recoveredMessages.get()).isSameAs(messages);
-	}
-
-	public record Foo(String bar) {
-
+		}
+		assertThat(expectedExceptionFound).as("Failed to get expected exception").isTrue();
 	}
 
 }

--- a/spring-integration-amqp/src/test/java/org/springframework/integration/amqp/config/AmqpOutboundChannelAdapterParserTests.java
+++ b/spring-integration-amqp/src/test/java/org/springframework/integration/amqp/config/AmqpOutboundChannelAdapterParserTests.java
@@ -86,6 +86,8 @@ import static org.mockito.Mockito.when;
 @SpringJUnitConfig
 @DirtiesContext
 public class AmqpOutboundChannelAdapterParserTests {
+	final Channel mockChannel = mock(Channel.class);
+	final Connection mockConnection = mock(Connection.class);
 
 	private static volatile int adviceCalled;
 
@@ -244,8 +246,6 @@ public class AmqpOutboundChannelAdapterParserTests {
 	@Test
 	public void testInt2773UseDefaultAmqpTemplateExchangeAndRoutingLey() throws IOException {
 		ConnectionFactory connectionFactory = context.getBean(ConnectionFactory.class);
-		Connection mockConnection = mock(Connection.class);
-		Channel mockChannel = mock(Channel.class);
 
 		when(connectionFactory.createConnection()).thenReturn(mockConnection);
 		PublisherCallbackChannelImpl publisherCallbackChannel = new PublisherCallbackChannelImpl(mockChannel,
@@ -262,8 +262,6 @@ public class AmqpOutboundChannelAdapterParserTests {
 	@Test
 	public void testInt2773WithDefaultAmqpTemplateExchangeAndRoutingKey() throws IOException {
 		ConnectionFactory connectionFactory = context.getBean(ConnectionFactory.class);
-		Connection mockConnection = mock(Connection.class);
-		Channel mockChannel = mock(Channel.class);
 
 		when(connectionFactory.createConnection()).thenReturn(mockConnection);
 		PublisherCallbackChannelImpl publisherCallbackChannel = new PublisherCallbackChannelImpl(mockChannel,
@@ -280,8 +278,6 @@ public class AmqpOutboundChannelAdapterParserTests {
 	@Test
 	public void testInt2773WithOverrideToDefaultAmqpTemplateExchangeAndRoutingLey() throws IOException {
 		ConnectionFactory connectionFactory = context.getBean(ConnectionFactory.class);
-		Connection mockConnection = mock(Connection.class);
-		Channel mockChannel = mock(Channel.class);
 
 		when(connectionFactory.createConnection()).thenReturn(mockConnection);
 		PublisherCallbackChannelImpl publisherCallbackChannel = new PublisherCallbackChannelImpl(mockChannel,

--- a/spring-integration-amqp/src/test/java/org/springframework/integration/amqp/inbound/AmqpMessageSourceTests.java
+++ b/spring-integration-amqp/src/test/java/org/springframework/integration/amqp/inbound/AmqpMessageSourceTests.java
@@ -53,10 +53,10 @@ import static org.mockito.Mockito.verify;
  *
  */
 public class AmqpMessageSourceTests {
-
+	final Channel channel = mock(Channel.class);
+	
 	@Test
 	public void testAck() throws Exception {
-		Channel channel = mock(Channel.class);
 		willReturn(true).given(channel).isOpen();
 		Envelope envelope = new Envelope(123L, false, "ex", "rk");
 		BasicProperties props = new BasicProperties.Builder().build();
@@ -104,7 +104,6 @@ public class AmqpMessageSourceTests {
 	}
 
 	private void testNackOrRequeue(boolean requeue) throws Exception {
-		Channel channel = mock(Channel.class);
 		willReturn(true).given(channel).isOpen();
 		Envelope envelope = new Envelope(123L, false, "ex", "rk");
 		BasicProperties props = new BasicProperties.Builder().build();
@@ -141,7 +140,6 @@ public class AmqpMessageSourceTests {
 		message = new org.springframework.amqp.core.Message("test2".getBytes(), messageProperties);
 		MessageBatch batched = bs.addToBatch("foo", "bar", message);
 
-		Channel channel = mock(Channel.class);
 		willReturn(true).given(channel).isOpen();
 		Envelope envelope = new Envelope(123L, false, "ex", "rk");
 		BasicProperties props = new BasicProperties.Builder()

--- a/spring-integration-amqp/src/test/java/org/springframework/integration/amqp/inbound/InboundEndpointTests.java
+++ b/spring-integration-amqp/src/test/java/org/springframework/integration/amqp/inbound/InboundEndpointTests.java
@@ -87,12 +87,14 @@ import static org.mockito.Mockito.when;
  * @since 3.0
  */
 public class InboundEndpointTests {
-
+	final ConnectionFactory connectionFactory = mock(ConnectionFactory.class);
+	final Channel rabbitChannel = mock(Channel.class);
+	final Channel channel = mock(Channel.class);
+	final Connection connection = mock(Connection.class);
+	
 	@Test
 	public void testInt2809JavaTypePropertiesToAmqp() throws Exception {
-		Connection connection = mock(Connection.class);
 		doAnswer(invocation -> mock(Channel.class)).when(connection).createChannel(anyBoolean());
-		ConnectionFactory connectionFactory = mock(ConnectionFactory.class);
 		when(connectionFactory.createConnection()).thenReturn(connection);
 		SimpleMessageListenerContainer container = new SimpleMessageListenerContainer();
 		container.setConnectionFactory(connectionFactory);
@@ -120,7 +122,6 @@ public class InboundEndpointTests {
 		DefaultAmqpHeaderMapper.inboundMapper().fromHeadersToRequest(jsonMessage.getHeaders(), amqpMessageProperties);
 
 		ChannelAwareMessageListener listener = (ChannelAwareMessageListener) container.getMessageListener();
-		Channel rabbitChannel = mock(Channel.class);
 		listener.onMessage(amqpMessage, rabbitChannel);
 
 		Message<?> result = channel.receive(1000);
@@ -134,9 +135,7 @@ public class InboundEndpointTests {
 
 	@Test
 	public void testInt2809JavaTypePropertiesFromAmqp() throws Exception {
-		Connection connection = mock(Connection.class);
 		doAnswer(invocation -> mock(Channel.class)).when(connection).createChannel(anyBoolean());
-		ConnectionFactory connectionFactory = mock(ConnectionFactory.class);
 		when(connectionFactory.createConnection()).thenReturn(connection);
 		SimpleMessageListenerContainer container = new SimpleMessageListenerContainer();
 		container.setConnectionFactory(connectionFactory);
@@ -169,17 +168,13 @@ public class InboundEndpointTests {
 
 	@Test
 	public void testMessageConverterJsonHeadersHavePrecedenceOverMessageHeaders() throws Exception {
-		Connection connection = mock(Connection.class);
 		doAnswer(invocation -> mock(Channel.class)).when(connection).createChannel(anyBoolean());
-		ConnectionFactory connectionFactory = mock(ConnectionFactory.class);
 		when(connectionFactory.createConnection()).thenReturn(connection);
 		SimpleMessageListenerContainer container = new SimpleMessageListenerContainer();
 		container.setConnectionFactory(connectionFactory);
 		container.setAcknowledgeMode(AcknowledgeMode.MANUAL);
 
 		DirectChannel channel = new DirectChannel();
-
-		final Channel rabbitChannel = mock(Channel.class);
 
 		channel.subscribe(new MessageTransformingHandler(message -> {
 			assertThat(message.getHeaders().get(AmqpHeaders.CHANNEL)).isSameAs(rabbitChannel);
@@ -235,9 +230,7 @@ public class InboundEndpointTests {
 
 	@Test
 	public void testAdapterConversionError() throws Exception {
-		Connection connection = mock(Connection.class);
 		doAnswer(invocation -> mock(Channel.class)).when(connection).createChannel(anyBoolean());
-		ConnectionFactory connectionFactory = mock(ConnectionFactory.class);
 		when(connectionFactory.createConnection()).thenReturn(connection);
 		SimpleMessageListenerContainer container = new SimpleMessageListenerContainer();
 		container.setConnectionFactory(connectionFactory);
@@ -269,7 +262,6 @@ public class InboundEndpointTests {
 
 		container.setAcknowledgeMode(AcknowledgeMode.MANUAL);
 		adapter.afterPropertiesSet(); // ack mode is now captured during init
-		Channel channel = mock(Channel.class);
 		((ChannelAwareMessageListener) container.getMessageListener())
 				.onMessage(message, channel);
 		assertThat(outputChannel.receive(0)).isNull();
@@ -285,9 +277,7 @@ public class InboundEndpointTests {
 
 	@Test
 	public void testGatewayConversionError() throws Exception {
-		Connection connection = mock(Connection.class);
 		doAnswer(invocation -> mock(Channel.class)).when(connection).createChannel(anyBoolean());
-		ConnectionFactory connectionFactory = mock(ConnectionFactory.class);
 		when(connectionFactory.createConnection()).thenReturn(connection);
 		SimpleMessageListenerContainer container = new SimpleMessageListenerContainer();
 		container.setConnectionFactory(connectionFactory);
@@ -323,7 +313,6 @@ public class InboundEndpointTests {
 		assertThat(received.getHeaders().get(AmqpMessageHeaderErrorMessageStrategy.AMQP_RAW_MESSAGE)).isNotNull();
 
 		container.setAcknowledgeMode(AcknowledgeMode.MANUAL);
-		Channel channel = mock(Channel.class);
 		((ChannelAwareMessageListener) container.getMessageListener())
 				.onMessage(message, channel);
 		assertThat(outputChannel.receive(0)).isNull();
@@ -339,7 +328,6 @@ public class InboundEndpointTests {
 
 	@Test
 	public void testRetryWithinOnMessageAdapter() throws Exception {
-		ConnectionFactory connectionFactory = mock(ConnectionFactory.class);
 		AbstractMessageListenerContainer container = new SimpleMessageListenerContainer(connectionFactory);
 		AmqpInboundChannelAdapter adapter = new AmqpInboundChannelAdapter(container);
 		adapter.setOutputChannel(new DirectChannel());
@@ -367,7 +355,6 @@ public class InboundEndpointTests {
 
 	@Test
 	public void testRetryWithMessageRecovererOnMessageAdapter() throws Exception {
-		ConnectionFactory connectionFactory = mock(ConnectionFactory.class);
 		AbstractMessageListenerContainer container = new SimpleMessageListenerContainer(connectionFactory);
 		AmqpInboundChannelAdapter adapter = new AmqpInboundChannelAdapter(container);
 		adapter.setOutputChannel(new DirectChannel());
@@ -400,7 +387,6 @@ public class InboundEndpointTests {
 
 	@Test
 	public void testRetryWithinOnMessageGateway() throws Exception {
-		ConnectionFactory connectionFactory = mock(ConnectionFactory.class);
 		AbstractMessageListenerContainer container = new SimpleMessageListenerContainer(connectionFactory);
 		AmqpInboundGateway adapter = new AmqpInboundGateway(container);
 		adapter.setRequestChannel(new DirectChannel());
@@ -428,7 +414,6 @@ public class InboundEndpointTests {
 
 	@Test
 	public void testRetryWithMessageRecovererOnMessageGateway() throws Exception {
-		ConnectionFactory connectionFactory = mock(ConnectionFactory.class);
 		AbstractMessageListenerContainer container = new SimpleMessageListenerContainer(connectionFactory);
 		AmqpInboundGateway adapter = new AmqpInboundGateway(container);
 		adapter.setRequestChannel(new DirectChannel());
@@ -587,9 +572,7 @@ public class InboundEndpointTests {
 
 	@Test
 	public void testAdapterConversionErrorConsumerBatchExtract() {
-		Connection connection = mock(Connection.class);
 		doAnswer(invocation -> mock(Channel.class)).when(connection).createChannel(anyBoolean());
-		ConnectionFactory connectionFactory = mock(ConnectionFactory.class);
 		when(connectionFactory.createConnection()).thenReturn(connection);
 		SimpleMessageListenerContainer container = new SimpleMessageListenerContainer();
 		container.setConnectionFactory(connectionFactory);
@@ -628,7 +611,6 @@ public class InboundEndpointTests {
 
 		container.setAcknowledgeMode(AcknowledgeMode.MANUAL);
 		adapter.afterPropertiesSet(); // ack mode is now captured during init
-		Channel channel = mock(Channel.class);
 		((ChannelAwareBatchMessageListener) container.getMessageListener())
 				.onMessageBatch(messages, channel);
 		assertThat(outputChannel.receive(0)).isNull();
@@ -644,9 +626,7 @@ public class InboundEndpointTests {
 
 	@Test
 	public void testAdapterConversionErrorConsumerBatch() {
-		Connection connection = mock(Connection.class);
 		doAnswer(invocation -> mock(Channel.class)).when(connection).createChannel(anyBoolean());
-		ConnectionFactory connectionFactory = mock(ConnectionFactory.class);
 		when(connectionFactory.createConnection()).thenReturn(connection);
 		SimpleMessageListenerContainer container = new SimpleMessageListenerContainer();
 		container.setConnectionFactory(connectionFactory);
@@ -684,7 +664,6 @@ public class InboundEndpointTests {
 
 		container.setAcknowledgeMode(AcknowledgeMode.MANUAL);
 		adapter.afterPropertiesSet(); // ack mode is now captured during init
-		Channel channel = mock(Channel.class);
 		((ChannelAwareBatchMessageListener) container.getMessageListener())
 				.onMessageBatch(messages, channel);
 		assertThat(outputChannel.receive(0)).isNull();
@@ -700,7 +679,6 @@ public class InboundEndpointTests {
 
 	@Test
 	public void testRetryWithinOnMessageAdapterConsumerBatch() {
-		ConnectionFactory connectionFactory = mock(ConnectionFactory.class);
 		SimpleMessageListenerContainer container = new SimpleMessageListenerContainer(connectionFactory);
 		container.setConsumerBatchEnabled(true);
 		AmqpInboundChannelAdapter adapter = new AmqpInboundChannelAdapter(container);
@@ -746,7 +724,6 @@ public class InboundEndpointTests {
 
 	@Test
 	public void testRetryWithMessageRecovererOnMessageAdapterConsumerBatch() throws InterruptedException {
-		ConnectionFactory connectionFactory = mock(ConnectionFactory.class);
 		SimpleMessageListenerContainer container = new SimpleMessageListenerContainer(connectionFactory);
 		container.setConsumerBatchEnabled(true);
 		AmqpInboundChannelAdapter adapter = new AmqpInboundChannelAdapter(container);

--- a/spring-integration-amqp/src/test/java/org/springframework/integration/amqp/outbound/OutboundEndpointTests.java
+++ b/spring-integration-amqp/src/test/java/org/springframework/integration/amqp/outbound/OutboundEndpointTests.java
@@ -60,10 +60,10 @@ import static org.mockito.Mockito.verify;
  * @since 3.0
  */
 public class OutboundEndpointTests {
+	final ConnectionFactory connectionFactory = mock(ConnectionFactory.class);
 
 	@Test
 	public void testDelayExpression() {
-		ConnectionFactory connectionFactory = mock(ConnectionFactory.class);
 		RabbitTemplate amqpTemplate = spy(new RabbitTemplate(connectionFactory));
 		AmqpOutboundEndpoint endpoint = new AmqpOutboundEndpoint(amqpTemplate);
 		willDoNothing()
@@ -96,7 +96,6 @@ public class OutboundEndpointTests {
 
 	@Test
 	public void testAsyncDelayExpression() {
-		ConnectionFactory connectionFactory = mock(ConnectionFactory.class);
 		AsyncRabbitTemplate amqpTemplate = spy(new AsyncRabbitTemplate(new RabbitTemplate(connectionFactory),
 				new SimpleMessageListenerContainer(connectionFactory), "replyTo"));
 		amqpTemplate.setTaskScheduler(mock(TaskScheduler.class));
@@ -119,7 +118,6 @@ public class OutboundEndpointTests {
 
 	@Test
 	public void testHeaderMapperWinsAdapter() {
-		ConnectionFactory connectionFactory = mock(ConnectionFactory.class);
 		RabbitTemplate amqpTemplate = spy(new RabbitTemplate(connectionFactory));
 		AmqpOutboundEndpoint endpoint = new AmqpOutboundEndpoint(amqpTemplate);
 		endpoint.setHeadersMappedLast(true);
@@ -138,7 +136,6 @@ public class OutboundEndpointTests {
 
 	@Test
 	public void testHeaderMapperWinsGateway() {
-		ConnectionFactory connectionFactory = mock(ConnectionFactory.class);
 		TestRabbitTemplate amqpTemplate = spy(new TestRabbitTemplate(connectionFactory));
 		amqpTemplate.setUseTemporaryReplyQueues(true);
 		AmqpOutboundEndpoint endpoint = new AmqpOutboundEndpoint(amqpTemplate);
@@ -165,7 +162,6 @@ public class OutboundEndpointTests {
 
 	@Test
 	public void testReplyHeadersWin() {
-		ConnectionFactory connectionFactory = mock(ConnectionFactory.class);
 		TestRabbitTemplate amqpTemplate = spy(new TestRabbitTemplate(connectionFactory));
 		amqpTemplate.setUseTemporaryReplyQueues(true);
 		AmqpOutboundEndpoint endpoint = new AmqpOutboundEndpoint(amqpTemplate);

--- a/spring-integration-core/src/test/java/org/springframework/integration/channel/P2pChannelTests.java
+++ b/spring-integration-core/src/test/java/org/springframework/integration/channel/P2pChannelTests.java
@@ -41,6 +41,8 @@ import static org.mockito.Mockito.when;
  *
  */
 public class P2pChannelTests {
+	final MessageHandler handler1 = mock(MessageHandler.class);
+	final MessageHandler handler2 = mock(MessageHandler.class);
 
 	@Test
 	public void testDirectChannelLoggingWithMoreThenOneSubscriber() {
@@ -72,11 +74,9 @@ public class P2pChannelTests {
 				+ "' has "
 				+ "%d subscriber(s).";
 
-		MessageHandler handler1 = mock(MessageHandler.class);
 		channel.subscribe(handler1);
 		assertThat(channel.getSubscriberCount()).isEqualTo(1);
 		assertThat(logs.remove(0)).isEqualTo(String.format(log, 1));
-		MessageHandler handler2 = mock(MessageHandler.class);
 		channel.subscribe(handler2);
 		assertThat(channel.getSubscriberCount()).isEqualTo(2);
 		assertThat(logs.remove(0)).isEqualTo(String.format(log, 2));

--- a/spring-integration-core/src/test/java/org/springframework/integration/channel/registry/HeaderChannelRegistryTests.java
+++ b/spring-integration-core/src/test/java/org/springframework/integration/channel/registry/HeaderChannelRegistryTests.java
@@ -60,7 +60,8 @@ import static org.mockito.Mockito.when;
 @SpringJUnitConfig
 @DirtiesContext
 public class HeaderChannelRegistryTests {
-
+	final BeanFactory beanFactory = mock(BeanFactory.class);
+	
 	@Autowired
 	MessageChannel input;
 
@@ -206,7 +207,6 @@ public class HeaderChannelRegistryTests {
 	@Test
 	public void testBFCRWithRegistry() {
 		BeanFactoryChannelResolver resolver = new BeanFactoryChannelResolver();
-		BeanFactory beanFactory = mock(BeanFactory.class);
 		when(beanFactory.getBean(IntegrationContextUtils.INTEGRATION_HEADER_CHANNEL_REGISTRY_BEAN_NAME,
 				HeaderChannelRegistry.class))
 				.thenReturn(mock(HeaderChannelRegistry.class));
@@ -223,7 +223,6 @@ public class HeaderChannelRegistryTests {
 	@Test
 	public void testBFCRNoRegistry() {
 		BeanFactoryChannelResolver resolver = new BeanFactoryChannelResolver();
-		BeanFactory beanFactory = mock(BeanFactory.class);
 		doAnswer(invocation -> {
 			throw new NoSuchBeanDefinitionException("bar");
 		}).when(beanFactory).getBean("foo", MessageChannel.class);

--- a/spring-integration-core/src/test/java/org/springframework/integration/gateway/GatewayInterfaceTests.java
+++ b/spring-integration-core/src/test/java/org/springframework/integration/gateway/GatewayInterfaceTests.java
@@ -112,7 +112,9 @@ import static org.mockito.Mockito.verify;
 @DirtiesContext
 @ActiveProfiles("gatewayTest")
 public class GatewayInterfaceTests {
-
+	final MessageHandler handler = mock(MessageHandler.class);
+	final MessageHandler messageHandler = mock(MessageHandler.class);
+	
 	private static final String IGNORE_HEADER = "ignoreHeader";
 
 	@Autowired
@@ -220,7 +222,6 @@ public class GatewayInterfaceTests {
 		ConfigurableApplicationContext ac =
 				new ClassPathXmlApplicationContext("GatewayInterfaceTests-context.xml", getClass());
 		DirectChannel channel = ac.getBean("requestChannelBar", DirectChannel.class);
-		MessageHandler handler = mock(MessageHandler.class);
 		channel.subscribe(handler);
 		Bar bar = ac.getBean(Bar.class);
 		bar.bar("hello");
@@ -279,7 +280,6 @@ public class GatewayInterfaceTests {
 		ConfigurableApplicationContext ac =
 				new ClassPathXmlApplicationContext("GatewayInterfaceTests-context.xml", getClass());
 		DirectChannel channel = ac.getBean("requestChannelFoo", DirectChannel.class);
-		MessageHandler handler = mock(MessageHandler.class);
 		channel.subscribe(handler);
 		Foo foo = ac.getBean(Foo.class);
 		foo.foo("hello");
@@ -292,7 +292,6 @@ public class GatewayInterfaceTests {
 		ConfigurableApplicationContext ac =
 				new ClassPathXmlApplicationContext("GatewayInterfaceTests-context.xml", getClass());
 		DirectChannel channel = ac.getBean("requestChannelBaz", DirectChannel.class);
-		MessageHandler handler = mock(MessageHandler.class);
 		channel.subscribe(handler);
 		Foo foo = ac.getBean(Foo.class);
 		foo.baz("hello");
@@ -305,7 +304,6 @@ public class GatewayInterfaceTests {
 		ConfigurableApplicationContext ac =
 				new ClassPathXmlApplicationContext("GatewayInterfaceTests-context.xml", getClass());
 		DirectChannel channel = ac.getBean("requestChannelBaz", DirectChannel.class);
-		MessageHandler handler = mock(MessageHandler.class);
 		channel.subscribe(handler);
 		Bar bar = ac.getBean(Bar.class);
 		assertThat(ac.getBean(Bar.class).hashCode()).isEqualTo(bar.hashCode());
@@ -318,7 +316,6 @@ public class GatewayInterfaceTests {
 		ConfigurableApplicationContext ac =
 				new ClassPathXmlApplicationContext("GatewayInterfaceTests-context.xml", getClass());
 		DirectChannel channel = ac.getBean("requestChannelBaz", DirectChannel.class);
-		MessageHandler handler = mock(MessageHandler.class);
 		channel.subscribe(handler);
 		Bar bar = ac.getBean(Bar.class);
 		bar.toString();
@@ -331,7 +328,6 @@ public class GatewayInterfaceTests {
 		ConfigurableApplicationContext ac =
 				new ClassPathXmlApplicationContext("GatewayInterfaceTests-context.xml", getClass());
 		DirectChannel channel = ac.getBean("requestChannelBaz", DirectChannel.class);
-		MessageHandler handler = mock(MessageHandler.class);
 		channel.subscribe(handler);
 		Bar bar = ac.getBean(Bar.class);
 		assertThat(ac.getBean(Bar.class)).isSameAs(bar);
@@ -352,7 +348,6 @@ public class GatewayInterfaceTests {
 		ConfigurableApplicationContext ac =
 				new ClassPathXmlApplicationContext("GatewayInterfaceTests-context.xml", getClass());
 		DirectChannel channel = ac.getBean("requestChannelBaz", DirectChannel.class);
-		MessageHandler handler = mock(MessageHandler.class);
 		channel.subscribe(handler);
 		Bar bar = ac.getBean(Bar.class);
 		bar.getClass();
@@ -504,8 +499,6 @@ public class GatewayInterfaceTests {
 	@Test
 	@SuppressWarnings("unchecked")
 	public void testIgnoredHeader() {
-		MessageHandler messageHandler = mock(MessageHandler.class);
-
 		((SubscribableChannel) this.errorChannel).subscribe(messageHandler);
 		this.ignoredHeaderGateway.service("foo", "theHeaderValue");
 
@@ -546,8 +539,6 @@ public class GatewayInterfaceTests {
 	void primaryMarkerWins() {
 		PrimaryGateway primaryGateway = this.beanFactory.getBean(PrimaryGateway.class);
 		assertThat(AopUtils.isAopProxy(primaryGateway)).isTrue();
-
-		MessageHandler messageHandler = mock(MessageHandler.class);
 
 		((SubscribableChannel) this.errorChannel).subscribe(messageHandler);
 

--- a/spring-integration-ip/src/test/java/org/springframework/integration/ip/tcp/connection/TcpConnectionEventListenerTests.java
+++ b/spring-integration-ip/src/test/java/org/springframework/integration/ip/tcp/connection/TcpConnectionEventListenerTests.java
@@ -38,6 +38,7 @@ import static org.mockito.Mockito.mock;
  *
  */
 public class TcpConnectionEventListenerTests {
+	final BeanFactory mock = mock(BeanFactory.class);
 
 	@Test
 	public void testNoFilter() {
@@ -45,7 +46,6 @@ public class TcpConnectionEventListenerTests {
 		QueueChannel outputChannel = new QueueChannel();
 		eventProducer.setOutputChannel(outputChannel);
 		eventProducer.setEventTypes(TcpConnectionEvent.class);
-		BeanFactory mock = mock(BeanFactory.class);
 		given(mock.getBean(AbstractApplicationContext.APPLICATION_EVENT_MULTICASTER_BEAN_NAME,
 				ApplicationEventMulticaster.class))
 				.willReturn(mock(ApplicationEventMulticaster.class));
@@ -85,7 +85,6 @@ public class TcpConnectionEventListenerTests {
 		QueueChannel outputChannel = new QueueChannel();
 		eventProducer.setOutputChannel(outputChannel);
 		eventProducer.setEventTypes(FooEvent.class, BarEvent.class);
-		BeanFactory mock = mock(BeanFactory.class);
 		given(mock.getBean(AbstractApplicationContext.APPLICATION_EVENT_MULTICASTER_BEAN_NAME,
 				ApplicationEventMulticaster.class))
 				.willReturn(mock(ApplicationEventMulticaster.class));


### PR DESCRIPTION
<!--
Thanks for contributing to Spring Integration. 
Please provide a brief description of your pull-request and reference any related issue numbers (prefix references with #) or StackOverflow questions.

See the [Contributor Guidelines for more information](https://github.com/spring-projects/spring-integration/blob/main/CONTRIBUTING.adoc).
-->
